### PR TITLE
feat: add demo_url field to Project model and schemas

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -16,6 +16,7 @@ class Project(SQLModel, table=True):
     slug: str = Field(unique=True, index=True, max_length=200)
     description: str | None = Field(default=None, max_length=5000)
     published: bool = True
+    demo_url: str | None = Field(default=None, max_length=500)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -14,6 +14,7 @@ class ProjectCreate(BaseModel):
     description: str | None = Field(default=None, max_length=5000)
     tags: list[str] = []
     published: bool = True
+    demo_url: str | None = Field(default=None, max_length=500)
 
 
 class ProjectUpdate(BaseModel):
@@ -22,6 +23,7 @@ class ProjectUpdate(BaseModel):
     description: str | None = Field(default=None, max_length=5000)
     tags: list[str] | None = None
     published: bool | None = None
+    demo_url: str | None = Field(default=None, max_length=500)
 
 
 class ProjectRead(BaseModel):
@@ -30,6 +32,7 @@ class ProjectRead(BaseModel):
     slug: str
     description: str | None
     published: bool
+    demo_url: str | None
     created_at: datetime
     updated_at: datetime
     tags: list[TagRead]

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -235,3 +235,31 @@ def test_update_project_tags_empty(admin_client: TestClient, project: Project) -
 def test_delete_project_not_found(admin_client: TestClient) -> None:
     response = admin_client.delete("/api/projects/nonexistent")
     assert response.status_code == 404
+
+
+def test_create_project_with_demo_url(
+    admin_client: TestClient, session: Session
+) -> None:
+    response = admin_client.post(
+        "/api/projects",
+        json={
+            "title": "demo-project",
+            "slug": "demo-project",
+            "description": "a project with demo",
+            "tags": [],
+            "published": True,
+            "demo_url": "https://demo.example.com",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["demo_url"] == "https://demo.example.com"
+
+
+def test_update_project_demo_url(admin_client: TestClient, project: Project) -> None:
+    response = admin_client.put(
+        "/api/projects/a-new-project", json={"demo_url": "https://demo.example.com"}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["demo_url"] == "https://demo.example.com"


### PR DESCRIPTION
## Résumé

- Ajout du champ `demo_url` au modèle `Project`
- Ajout dans les schémas `ProjectCreate`, `ProjectUpdate` et `ProjectRead`
- Champ optionnel (`str | None`), max 500 caractères

## Type de changement

- [x] Nouvelle fonctionnalité

## Tests

- [x] Les tests existants passent (`uv run pytest`)
- [x] De nouveaux tests ont été ajoutés (`test_create_project_with_demo_url`, `test_update_project_demo_url`)

## Checklist

- [x] Le code respecte les conventions du projet (`ruff`, `mypy`)
- [x] La PR est liée à une issue (Closes #27)