### PR TITLE
refactor: split projects routes into public and admin routers

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,7 +11,7 @@ from slowapi.errors import RateLimitExceeded
 from app.config import get_settings
 from app.limiter import limiter
 from app.logging import setup_logging
-from app.routers import auth, contact, profile, projects
+from app.routers import admin_projects, auth, contact, profile, projects
 
 settings = get_settings()
 
@@ -43,6 +43,7 @@ app.include_router(projects.router, prefix=settings.api_prefix)
 app.include_router(auth.router, prefix=settings.api_prefix)
 app.include_router(profile.router, prefix=settings.api_prefix)
 app.include_router(contact.router, prefix=settings.api_prefix)
+app.include_router(admin_projects.router, prefix=settings.api_prefix)
 
 
 @app.exception_handler(Exception)

--- a/backend/app/routers/admin_projects.py
+++ b/backend/app/routers/admin_projects.py
@@ -1,0 +1,116 @@
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import Session, select
+
+from app.auth import get_current_admin
+from app.database import get_session
+from app.models import Project, Tag
+from app.routers.projects import get_project_or_404
+from app.schemas import ProjectCreate, ProjectRead, ProjectUpdate
+
+router = APIRouter(prefix="/admin/projects", tags=["admin/projects"])
+logger = structlog.get_logger()
+
+
+@router.get("", response_model=list[ProjectRead])
+def list_all_projects(
+    session: Session = Depends(get_session), _: str = Depends(get_current_admin)
+) -> Sequence[Project]:
+    """List all project including unpublished drafts (admin only)."""
+    return session.exec(select(Project)).all()
+
+
+@router.post("", response_model=ProjectRead, status_code=status.HTTP_201_CREATED)
+def create_project(
+    data: ProjectCreate,
+    session: Session = Depends(get_session),
+    _: str = Depends(get_current_admin),
+) -> Project:
+    """Create a new project (admin only).
+
+    Returns 409 if a project with the same slug already exists.
+    Tags are created automatically if they do not exist yet.
+    """
+    try:
+        project = Project(**data.model_dump(exclude={"tags"}))
+        session.add(project)
+
+        for tag_name in data.tags:
+            tag: Tag | None = session.exec(
+                select(Tag).where(Tag.name == tag_name)
+            ).first()
+            if tag is None:
+                tag = Tag(name=tag_name)
+            project.tags.append(tag)
+        session.commit()
+        session.refresh(project)
+
+        logger.info("Project created", slug=project.slug)
+        return project
+
+    except IntegrityError as error:
+        session.rollback()
+        logger.warning("Duplicate project slug", slug=data.slug)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Project with this slug already exists.",
+        ) from error
+
+
+@router.put("/{slug}", response_model=ProjectRead)
+def update_project(
+    slug: str,
+    data: ProjectUpdate,
+    session: Session = Depends(get_session),
+    _: str = Depends(get_current_admin),
+) -> Project:
+    """Update a project by its slug (admin only).
+
+    Only provided fields are updated. Providing `tags` fully replaces the existing tag list;
+    pass an empty list to remove all tags.
+    Returns 404 if the project does not exist."""
+    project = get_project_or_404(slug, session)
+
+    update_data = data.model_dump(exclude_unset=True)
+    tag_names = update_data.pop("tags", None)
+
+    for key, value in update_data.items():
+        setattr(project, key, value)
+
+    if tag_names is not None:
+        project.tags.clear()
+        for tag_name in tag_names:
+            tag: Tag | None = session.exec(
+                select(Tag).where(Tag.name == tag_name)
+            ).first()
+            if tag is None:
+                tag = Tag(name=tag_name)
+            project.tags.append(tag)
+    project.updated_at = datetime.now(UTC)
+
+    session.add(project)
+    session.commit()
+    session.refresh(project)
+
+    logger.info("Project updated", slug=slug)
+    return project
+
+
+@router.delete("/{slug}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_project(
+    slug: str,
+    session: Session = Depends(get_session),
+    _: str = Depends(get_current_admin),
+) -> None:
+    """Delete a project by its slug (admin only).
+
+    Returns 404 if the project does not exist."""
+    project = get_project_or_404(slug, session)
+
+    session.delete(project)
+    session.commit()
+    logger.info("Project deleted", slug=slug)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,16 +1,13 @@
 from collections.abc import Sequence
-from datetime import UTC, datetime
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import true
-from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
-from app.auth import get_current_admin, get_optional_admin
 from app.database import get_session
-from app.models import Project, Tag
-from app.schemas import ProjectCreate, ProjectRead, ProjectUpdate
+from app.models import Project
+from app.schemas import ProjectRead
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 logger = structlog.get_logger()
@@ -18,20 +15,13 @@ logger = structlog.get_logger()
 
 @router.get("", response_model=list[ProjectRead])
 def list_projects(
-    all: bool = False,
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=10, ge=1, le=100),
     session: Session = Depends(get_session),
-    admin: str | None = Depends(get_optional_admin),
 ) -> Sequence[Project]:
-    """List projects.
+    """List published projects.
 
-    Returns only published projects by default.
-    Admins can pass `all=true` to include unpublished drafts.
-    Supports pagination via `offset` and `limit` (max 100).
-    """
-    if all and admin:
-        return session.exec(select(Project)).all()
+    Supports pagination via `offset` and `limit` (max 100)."""
     statement = (
         select(Project).where(Project.published == true()).offset(offset).limit(limit)
     )
@@ -44,7 +34,7 @@ def get_project(slug: str, session: Session = Depends(get_session)) -> Project:
 
     Returns 404 if the project does not exist or is not published.
     """
-    project = _get_project_or_404(slug, session)
+    project = get_project_or_404(slug, session)
     if not project.published:
         logger.warning("Access to unpublished project denied", slug=slug)
         raise HTTPException(
@@ -53,100 +43,7 @@ def get_project(slug: str, session: Session = Depends(get_session)) -> Project:
     return project
 
 
-@router.post("", response_model=ProjectRead, status_code=status.HTTP_201_CREATED)
-def create_project(
-    data: ProjectCreate,
-    session: Session = Depends(get_session),
-    _: str = Depends(get_current_admin),
-) -> Project:
-    """Create a new project (admin only).
-
-    Returns 409 if a project with the same slug already exists.
-    Tags are created automatically if they do not exist yet.
-    """
-    try:
-        project = Project(**data.model_dump(exclude={"tags"}))
-        session.add(project)
-
-        for tag_name in data.tags:
-            tag: Tag | None = session.exec(
-                select(Tag).where(Tag.name == tag_name)
-            ).first()
-            if tag is None:
-                tag = Tag(name=tag_name)
-            project.tags.append(tag)
-        session.commit()
-        session.refresh(project)
-
-        logger.info("Project created", slug=project.slug)
-        return project
-
-    except IntegrityError as error:
-        session.rollback()
-
-        logger.warning("Duplicate project slug", slug=data.slug)
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Project with this slug already exists.",
-        ) from error
-
-
-@router.put("/{slug}", response_model=ProjectRead)
-def update_project(
-    slug: str,
-    data: ProjectUpdate,
-    session: Session = Depends(get_session),
-    _: str = Depends(get_current_admin),
-) -> Project:
-    """Update a project by its slug (admin only).
-
-    Only provided fields are updated. Providing `tags` fully replaces the existing tag list;
-    pass an empty list to remove all tags.
-    Returns 404 if the project does not exist."""
-    project = _get_project_or_404(slug, session)
-
-    update_data = data.model_dump(exclude_unset=True)
-    tag_names = update_data.pop("tags", None)
-
-    for key, value in update_data.items():
-        setattr(project, key, value)
-
-    if tag_names is not None:
-        project.tags.clear()
-        for tag_name in tag_names:
-            tag: Tag | None = session.exec(
-                select(Tag).where(Tag.name == tag_name)
-            ).first()
-            if tag is None:
-                tag = Tag(name=tag_name)
-            project.tags.append(tag)
-    project.updated_at = datetime.now(UTC)
-
-    session.add(project)
-    session.commit()
-    session.refresh(project)
-
-    logger.info("Project updated", slug=slug)
-    return project
-
-
-@router.delete("/{slug}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_project(
-    slug: str,
-    session: Session = Depends(get_session),
-    _: str = Depends(get_current_admin),
-) -> None:
-    """Delete a project by its slug (admin only).
-
-    Returns 404 if the project does not exist."""
-    project = _get_project_or_404(slug, session)
-
-    session.delete(project)
-    session.commit()
-    logger.info("Project deleted", slug=slug)
-
-
-def _get_project_or_404(slug: str, session: Session) -> Project:
+def get_project_or_404(slug: str, session: Session) -> Project:
     statement = select(Project).where(Project.slug == slug)
     project: Project | None = session.exec(statement).first()
     if project is None:

--- a/backend/tests/routers/test_admin_projects.py
+++ b/backend/tests/routers/test_admin_projects.py
@@ -1,0 +1,213 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from app.models import Project, Tag
+
+ADMIN_PROJECTS_URL = "api/admin/projects"
+
+
+@pytest.fixture
+def project(session: Session) -> Project:
+    project = Project(
+        title="a new project",
+        slug="a-new-project",
+        description="a description for a new project",
+        published=True,
+    )
+    session.add(project)
+    project.tags.append(Tag(name="python"))
+    project.tags.append(Tag(name="fastapi"))
+    session.commit()
+    session.refresh(project)
+    return project
+
+
+@pytest.fixture
+def unpublished_project(session: Session) -> Project:
+    unpublished = Project(
+        title="draft",
+        slug="draft",
+        description="wip",
+        published=False,
+    )
+    session.add(unpublished)
+    session.commit()
+    session.refresh(unpublished)
+    return unpublished
+
+
+def test_list_all_projects(
+    admin_client: TestClient, project: Project, unpublished_project: Project
+) -> None:
+    response = admin_client.get(ADMIN_PROJECTS_URL)
+    assert response.status_code == 200
+    slugs = [p["slug"] for p in response.json()]
+    assert "a-new-project" in slugs
+    assert "draft" in slugs
+
+
+def test_list_all_projects_requires_auth(client: TestClient) -> None:
+    response = client.get(ADMIN_PROJECTS_URL)
+    assert response.status_code == 401
+
+
+def test_create_project(admin_client: TestClient, session: Session) -> None:
+    response = admin_client.post(
+        ADMIN_PROJECTS_URL,
+        json={
+            "title": "good project",
+            "slug": "a-good-project",
+            "description": "a good project",
+            "tags": ["python", "vuejs"],
+            "published": True,
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["slug"] == "a-good-project"
+    assert data["title"] == "good project"
+    assert data["id"] is not None
+    assert len(data["tags"]) == 2
+
+    projects = session.exec(select(Project)).all()
+    tags = session.exec(select(Tag)).all()
+    assert len(projects) == 1
+    assert len(tags) == 2
+
+
+def test_create_project_without_auth(client: TestClient) -> None:
+    response = client.post(
+        ADMIN_PROJECTS_URL,
+        json={
+            "title": "good project",
+            "slug": "a-good-project",
+            "description": "a good project",
+            "tags": ["python", "vuejs"],
+            "published": True,
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_create_duplicate_slug(admin_client: TestClient, project: Project) -> None:
+    response = admin_client.post(
+        ADMIN_PROJECTS_URL,
+        json={
+            "title": "good project",
+            "slug": "a-new-project",
+            "description": "a good project",
+            "tags": ["python", "vuejs"],
+            "published": True,
+        },
+    )
+    assert response.status_code == 409
+
+
+def test_create_project_slug_case_sensitivity(
+    admin_client: TestClient, project: Project
+) -> None:
+    response = admin_client.post(
+        ADMIN_PROJECTS_URL,
+        json={
+            "title": "Another project",
+            "slug": "A-New-Project",
+            "description": "same slug different case",
+            "tags": [],
+            "published": True,
+        },
+    )
+    assert response.status_code in (201, 409)
+
+
+def test_create_project_with_demo_url(
+    admin_client: TestClient, session: Session
+) -> None:
+    response = admin_client.post(
+        ADMIN_PROJECTS_URL,
+        json={
+            "title": "demo-project",
+            "slug": "demo-project",
+            "description": "a project with demo",
+            "tags": [],
+            "published": True,
+            "demo_url": "https://demo.example.com",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["demo_url"] == "https://demo.example.com"
+
+
+def test_update_project(admin_client: TestClient, project: Project) -> None:
+    response = admin_client.put(
+        f"{ADMIN_PROJECTS_URL}/a-new-project", json={"description": "a new description"}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["description"] == "a new description"
+
+
+def test_update_project_without_auth(client: TestClient, project: Project) -> None:
+    response = client.put(
+        f"{ADMIN_PROJECTS_URL}/a-new-project", json={"description": "nope"}
+    )
+    assert response.status_code == 401
+
+
+def test_update_project_tags(admin_client: TestClient, project: Project) -> None:
+    response = admin_client.put(
+        f"{ADMIN_PROJECTS_URL}/a-new-project", json={"tags": ["django", "python"]}
+    )
+
+    assert response.status_code == 200
+    tags = [t["name"] for t in response.json()["tags"]]
+    assert "django" in tags
+    assert "python" in tags
+    assert "fastapi" not in tags
+
+
+def test_update_project_not_found(admin_client: TestClient) -> None:
+    response = admin_client.put(
+        f"{ADMIN_PROJECTS_URL}/nonexistent", json={"description": "nope"}
+    )
+    assert response.status_code == 404
+
+
+def test_update_project_tags_empty(admin_client: TestClient, project: Project) -> None:
+    response = admin_client.put(
+        f"{ADMIN_PROJECTS_URL}/a-new-project", json={"tags": []}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["tags"] == []
+
+
+def test_update_project_demo_url(admin_client: TestClient, project: Project) -> None:
+    response = admin_client.put(
+        f"{ADMIN_PROJECTS_URL}/a-new-project",
+        json={"demo_url": "https://demo.example.com"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["demo_url"] == "https://demo.example.com"
+
+
+def test_delete_project(admin_client: TestClient, project: Project) -> None:
+    response = admin_client.delete(f"{ADMIN_PROJECTS_URL}/a-new-project")
+    assert response.status_code == 204
+
+    response = admin_client.get("/api/projects/a-new-project")
+    assert response.status_code == 404
+
+
+def test_delete_project_without_auth(client: TestClient, project: Project) -> None:
+    response = client.delete(f"{ADMIN_PROJECTS_URL}/a-new-project")
+    assert response.status_code == 401
+
+
+def test_delete_project_not_found(admin_client: TestClient) -> None:
+    response = admin_client.delete(f"{ADMIN_PROJECTS_URL}/nonexistent")
+    assert response.status_code == 404

--- a/backend/tests/routers/test_auth.py
+++ b/backend/tests/routers/test_auth.py
@@ -4,11 +4,13 @@ import jwt
 from fastapi.testclient import TestClient
 
 _SECRET = "testsecretkey-that-is-long-enough-for-hs512-needs-at-least-64-bytes-here"
+AUTH_URL = "/api/auth"
 
 
 def test_login_success(client: TestClient) -> None:
     response = client.post(
-        "/api/auth/login", json={"email": "admin@test.com", "password": "testpassword"}
+        f"{AUTH_URL}/login",
+        json={"email": "admin@test.com", "password": "testpassword"},
     )
 
     assert response.status_code == 200
@@ -19,7 +21,7 @@ def test_login_success(client: TestClient) -> None:
 
 def test_login_wrong_password(client: TestClient) -> None:
     response = client.post(
-        "/api/auth/login",
+        f"{AUTH_URL}/login",
         json={
             "email": "admin@test.com",
             "password": "badpassword",
@@ -30,14 +32,14 @@ def test_login_wrong_password(client: TestClient) -> None:
 
 
 def test_me_without_token(client: TestClient) -> None:
-    response = client.get("/api/auth/me")
+    response = client.get(f"{AUTH_URL}/me")
 
     assert response.status_code == 401
     assert response.json()["detail"] == "Not authenticated"
 
 
 def test_me_with_token(admin_client: TestClient) -> None:
-    response = admin_client.get("/api/auth/me")
+    response = admin_client.get(f"{AUTH_URL}/me")
 
     assert response.status_code == 200
     assert response.json()["email"] == "admin@test.com"
@@ -45,7 +47,7 @@ def test_me_with_token(admin_client: TestClient) -> None:
 
 def test_login_nonexistent_email(client: TestClient) -> None:
     response = client.post(
-        "/api/auth/login",
+        f"{AUTH_URL}/login",
         json={"email": "nobody@test.com", "password": "testpassword"},
     )
     assert response.status_code == 401
@@ -58,14 +60,14 @@ def test_me_with_expired_token(client: TestClient) -> None:
         algorithm="HS256",
     )
     response = client.get(
-        "/api/auth/me", headers={"Authorization": f"Bearer {expired_token}"}
+        f"{AUTH_URL}/me", headers={"Authorization": f"Bearer {expired_token}"}
     )
     assert response.status_code == 401
 
 
 def test_me_with_invalid_token_format(client: TestClient) -> None:
     response = client.get(
-        "/api/auth/me", headers={"Authorization": "Bearer notavalidtoken"}
+        f"{AUTH_URL}/me", headers={"Authorization": "Bearer notavalidtoken"}
     )
     assert response.status_code == 401
 
@@ -77,6 +79,6 @@ def test_me_with_wrong_algorithm_token(client: TestClient) -> None:
         algorithm="HS512",
     )
     response = client.get(
-        "/api/auth/me", headers={"Authorization": f"Bearer {wrong_algo_token}"}
+        f"{AUTH_URL}/me", headers={"Authorization": f"Bearer {wrong_algo_token}"}
     )
     assert response.status_code == 401

--- a/backend/tests/routers/test_contact.py
+++ b/backend/tests/routers/test_contact.py
@@ -4,6 +4,8 @@ from sqlmodel import Session, select
 
 from app.models import ContactMessage
 
+CONTACT_URL = "/api/contact"
+
 
 @pytest.fixture
 def message(session: Session) -> ContactMessage:
@@ -18,7 +20,7 @@ def message(session: Session) -> ContactMessage:
 
 def test_send_message(client: TestClient, session: Session) -> None:
     response = client.post(
-        "/api/contact",
+        CONTACT_URL,
         json={
             "name": "a person",
             "email": "mail@test.com",
@@ -42,7 +44,7 @@ def test_send_message(client: TestClient, session: Session) -> None:
 
 def test_list_messages_admin(admin_client: TestClient, client: TestClient) -> None:
     client.post(
-        "/api/contact",
+        CONTACT_URL,
         json={
             "name": "first",
             "email": "first@test.com",
@@ -51,7 +53,7 @@ def test_list_messages_admin(admin_client: TestClient, client: TestClient) -> No
         },
     )
     client.post(
-        "/api/contact",
+        CONTACT_URL,
         json={
             "name": "second",
             "email": "second@test.com",
@@ -60,7 +62,7 @@ def test_list_messages_admin(admin_client: TestClient, client: TestClient) -> No
         },
     )
 
-    response = admin_client.get("/api/contact")
+    response = admin_client.get(CONTACT_URL)
     assert response.status_code == 200
 
     data = response.json()
@@ -73,7 +75,7 @@ def test_list_messages_admin(admin_client: TestClient, client: TestClient) -> No
 
 
 def test_list_messages_without_auth(client: TestClient) -> None:
-    response = client.get("/api/contact")
+    response = client.get(CONTACT_URL)
     assert response.status_code == 401
 
 
@@ -83,39 +85,39 @@ def test_mark_as_read(
     client: TestClient,
     message: ContactMessage,
 ) -> None:
-    response = admin_client.patch(f"/api/contact/{message.id}/read")
+    response = admin_client.patch(f"{CONTACT_URL}/{message.id}/read")
     assert response.status_code == 200
     assert message.read is True
 
 
 def test_mark_as_read_not_found(admin_client: TestClient) -> None:
-    response = admin_client.patch("/api/contact/999/read")
+    response = admin_client.patch(f"{CONTACT_URL}/999/read")
     assert response.status_code == 404
 
 
 def test_delete_message(admin_client: TestClient, message: ContactMessage) -> None:
-    response = admin_client.delete(f"/api/contact/{message.id}")
+    response = admin_client.delete(f"{CONTACT_URL}/{message.id}")
     assert response.status_code == 204
 
 
 def test_deleted_message_hidden_from_list(
     admin_client: TestClient, message: ContactMessage
 ) -> None:
-    admin_client.delete(f"/api/contact/{message.id}")
-    response = admin_client.get("/api/contact")
+    admin_client.delete(f"{CONTACT_URL}/{message.id}")
+    response = admin_client.get(CONTACT_URL)
     assert response.status_code == 200
     assert len(response.json()) == 0
 
 
 def test_delete_message_not_found(admin_client: TestClient) -> None:
-    response = admin_client.delete("/api/contact/999")
+    response = admin_client.delete(f"{CONTACT_URL}/999")
     assert response.status_code == 404
 
 
 def test_delete_message_without_auth(
     client: TestClient, message: ContactMessage
 ) -> None:
-    response = client.delete(f"/api/contact/{message.id}")
+    response = client.delete(f"{CONTACT_URL}/{message.id}")
     assert response.status_code == 401
 
 
@@ -131,7 +133,7 @@ def test_list_messages_pagination(admin_client: TestClient, session: Session) ->
         )
     session.commit()
 
-    response = admin_client.get("/api/contact?limit=2")
+    response = admin_client.get(f"{CONTACT_URL}?limit=2")
     assert response.status_code == 200
     assert len(response.json()) == 2
 
@@ -144,15 +146,15 @@ def test_create_message_rate_limited(client: TestClient) -> None:
         "message": "spam message",
     }
     for _ in range(5):
-        client.post("/api/contact/", json=payload)
+        client.post(f"{CONTACT_URL}/", json=payload)
 
-    response = client.post("/api/contact/", json=payload)
+    response = client.post(f"{CONTACT_URL}/", json=payload)
     assert response.status_code == 429
 
 
 def test_send_message_invalid_email(client: TestClient) -> None:
     response = client.post(
-        "/api/contact",
+        CONTACT_URL,
         json={
             "name": "a person",
             "email": "not-an-email",
@@ -165,7 +167,7 @@ def test_send_message_invalid_email(client: TestClient) -> None:
 
 def test_send_message_whitespace_only(client: TestClient) -> None:
     response = client.post(
-        "/api/contact/",
+        f"{CONTACT_URL}/",
         json={
             "name": "    ",
             "email": "mail@test.com",
@@ -178,7 +180,7 @@ def test_send_message_whitespace_only(client: TestClient) -> None:
 
 def test_send_message_too_long(client: TestClient) -> None:
     response = client.post(
-        "/api/contact",
+        CONTACT_URL,
         json={
             "name": "a person",
             "email": "mail@test.com",
@@ -203,6 +205,6 @@ def test_list_messages_pagination_offset_beyond_total(
         )
         session.commit()
 
-        response = admin_client.get("/api/contact?offset=10")
+        response = admin_client.get(f"{CONTACT_URL}?offset=10")
         assert response.status_code == 200
         assert response.json() == []

--- a/backend/tests/routers/test_profile.py
+++ b/backend/tests/routers/test_profile.py
@@ -3,9 +3,11 @@ from sqlmodel import Session, select
 
 from app.models import Skill
 
+PROFILE_URL = "/api/profile"
+
 
 def test_get_profile_auto_create(client: TestClient) -> None:
-    response = client.get("/api/profile")
+    response = client.get(PROFILE_URL)
 
     assert response.status_code == 200
     data = response.json()
@@ -16,7 +18,7 @@ def test_get_profile_auto_create(client: TestClient) -> None:
 
 def test_update_profile(admin_client: TestClient) -> None:
     response = admin_client.put(
-        "/api/profile",
+        PROFILE_URL,
         json={
             "full_name": "Jean-Pierre",
             "title": "Développeur",
@@ -33,7 +35,7 @@ def test_update_profile(admin_client: TestClient) -> None:
 
 def test_update_profile_with_skills(admin_client: TestClient) -> None:
     response = admin_client.put(
-        "/api/profile",
+        PROFILE_URL,
         json={
             "skills": [
                 {"name": "Python", "category": "backend", "level": 5},
@@ -51,14 +53,14 @@ def test_update_profile_with_skills(admin_client: TestClient) -> None:
 
 def test_update_profile_replaces_skills(admin_client: TestClient) -> None:
     admin_client.put(
-        "/api/profile",
+        PROFILE_URL,
         json={
             "skills": [{"name": "Python", "category": "backend", "level": 5}],
         },
     )
 
     response = admin_client.put(
-        "/api/profile",
+        PROFILE_URL,
         json={
             "skills": [{"name": "Go", "category": "backend", "level": 3}],
         },
@@ -72,7 +74,7 @@ def test_update_profile_replaces_skills(admin_client: TestClient) -> None:
 
 def test_update_profile_with_experiences(admin_client: TestClient) -> None:
     response = admin_client.put(
-        "/api/profile",
+        PROFILE_URL,
         json={
             "experiences": [
                 {
@@ -93,7 +95,7 @@ def test_update_profile_with_experiences(admin_client: TestClient) -> None:
 
 def test_update_profile_with_education(admin_client: TestClient) -> None:
     response = admin_client.put(
-        "/api/profile",
+        PROFILE_URL,
         json={
             "education": [
                 {"school": "MIT", "degree": "CS", "year": 2020},
@@ -108,15 +110,15 @@ def test_update_profile_with_education(admin_client: TestClient) -> None:
 
 
 def test_update_profile_without_auth(client: TestClient) -> None:
-    response = client.put("/api/profile", json={"full_name": "Nope"})
+    response = client.put(PROFILE_URL, json={"full_name": "Nope"})
 
     assert response.status_code == 401
 
 
 def test_update_profile_partial_update(admin_client: TestClient) -> None:
-    admin_client.put("/api/profile", json={"full_name": "Jean", "title": "Dev"})
+    admin_client.put(PROFILE_URL, json={"full_name": "Jean", "title": "Dev"})
 
-    response = admin_client.put("/api/profile", json={"bio": "new bio"})
+    response = admin_client.put(PROFILE_URL, json={"bio": "new bio"})
 
     assert response.status_code == 200
     data = response.json()
@@ -126,13 +128,13 @@ def test_update_profile_partial_update(admin_client: TestClient) -> None:
 
 def test_update_profile_invalid_skill_level(admin_client: TestClient) -> None:
     response = admin_client.put(
-        "/api/profile",
+        PROFILE_URL,
         json={"skills": [{"name": "Python", "category": "backend", "level": -1}]},
     )
     assert response.status_code == 422
 
     response = admin_client.put(
-        "/api/profile",
+        PROFILE_URL,
         json={"skills": [{"name": "Python", "category": "backend", "level": 11}]},
     )
     assert response.status_code == 422
@@ -142,12 +144,12 @@ def test_update_profile_cascade_deletes_skills(
     admin_client: TestClient, session: Session
 ) -> None:
     admin_client.put(
-        "/api/profile",
+        PROFILE_URL,
         json={"skills": [{"name": "Python", "category": "backend", "level": 5}]},
     )
     session.expire_all()
     assert len(session.exec(select(Skill)).all()) == 1
 
-    admin_client.put("/api/profile", json={"skills": []})
+    admin_client.put(PROFILE_URL, json={"skills": []})
     session.expire_all()
     assert len(session.exec(select(Skill)).all()) == 0

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -1,8 +1,10 @@
 import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session, select
+from sqlmodel import Session
 
 from app.models import Project, Tag
+
+PROJECTS_URL = "api/projects"
 
 
 @pytest.fixture
@@ -36,7 +38,7 @@ def unpublished_project(session: Session) -> Project:
 
 
 def test_list_projects_empty(client: TestClient) -> None:
-    response = client.get("/api/projects")
+    response = client.get(PROJECTS_URL)
 
     assert response.status_code == 200
     assert response.json() == []
@@ -45,140 +47,11 @@ def test_list_projects_empty(client: TestClient) -> None:
 def test_list_projects_hides_unpublished(
     client: TestClient, project: Project, unpublished_project: Project, session: Session
 ) -> None:
-    response = client.get("/api/projects")
+    response = client.get(PROJECTS_URL)
     assert response.status_code == 200
     slugs = [p["slug"] for p in response.json()]
     assert "a-new-project" in slugs
     assert "draft" not in slugs
-
-
-def test_list_projects_all_requires_admin(
-    client: TestClient,
-    project: Project,
-    unpublished_project: Project,
-    session: Session,
-) -> None:
-    response = client.get("/api/projects?all=true")
-    assert response.status_code == 200
-    slugs = [p["slug"] for p in response.json()]
-    assert "draft" not in slugs
-
-
-def test_list_projects_all_as_admin(
-    admin_client: TestClient,
-    project: Project,
-    unpublished_project: Project,
-    session: Session,
-) -> None:
-    response = admin_client.get("/api/projects?all=true")
-    assert response.status_code == 200
-    slugs = [p["slug"] for p in response.json()]
-    assert "a-new-project" in slugs
-    assert "draft" in slugs
-
-
-def test_create_project(admin_client: TestClient, session: Session) -> None:
-    response = admin_client.post(
-        "/api/projects",
-        json={
-            "title": "good project",
-            "slug": "a-good-project",
-            "description": "a good project",
-            "tags": ["python", "vuejs"],
-            "published": True,
-        },
-    )
-
-    assert response.status_code == 201
-    data = response.json()
-    assert data["slug"] == "a-good-project"
-    assert data["title"] == "good project"
-    assert data["id"] is not None
-    assert len(data["tags"]) == 2
-
-    projects = session.exec(select(Project)).all()
-    tags = session.exec(select(Tag)).all()
-    assert len(projects) == 1
-    assert len(tags) == 2
-
-
-def test_create_project_without_auth(client: TestClient) -> None:
-    response = client.post(
-        "/api/projects",
-        json={
-            "title": "good project",
-            "slug": "a-good-project",
-            "description": "a good project",
-            "tags": ["python", "vuejs"],
-            "published": True,
-        },
-    )
-
-    assert response.status_code == 401
-
-
-def test_create_duplicate_slug(admin_client: TestClient, project: Project) -> None:
-    response = admin_client.post(
-        "/api/projects",
-        json={
-            "title": "good project",
-            "slug": "a-new-project",
-            "description": "a good project",
-            "tags": ["python", "vuejs"],
-            "published": True,
-        },
-    )
-    assert response.status_code == 409
-
-
-def test_get_project_by_slug(admin_client: TestClient, project: Project) -> None:
-    response = admin_client.get("/api/projects/a-new-project")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["title"] == project.title
-    assert data["description"] == project.description
-    assert data["published"] is True
-
-
-def test_get_project_not_found(client: TestClient) -> None:
-    response = client.get("/api/projects/nope")
-    assert response.status_code == 404
-
-
-def test_get_project_not_published(
-    client: TestClient, unpublished_project: Project, session: Session
-) -> None:
-    response = client.get("/api/projects/draft")
-    assert response.status_code == 404
-
-
-def test_update_project(admin_client: TestClient, project: Project) -> None:
-    response = admin_client.put(
-        "/api/projects/a-new-project", json={"description": "a new description"}
-    )
-
-    assert response.status_code == 200
-    assert response.json()["description"] == "a new description"
-
-
-def test_update_project_tags(admin_client: TestClient, project: Project) -> None:
-    response = admin_client.put(
-        "/api/projects/a-new-project", json={"tags": ["django", "python"]}
-    )
-
-    assert response.status_code == 200
-    tags = [t["name"] for t in response.json()["tags"]]
-    assert "django" in tags
-    assert "python" in tags
-    assert "fastapi" not in tags
-
-
-def test_delete_project(admin_client: TestClient, project: Project) -> None:
-    response = admin_client.delete("/api/projects/a-new-project")
-    assert response.status_code == 204
-
-    response = admin_client.get("/api/projects/a-new-project")
-    assert response.status_code == 404
 
 
 def test_list_projects_pagination(admin_client: TestClient, session: Session) -> None:
@@ -193,73 +66,31 @@ def test_list_projects_pagination(admin_client: TestClient, session: Session) ->
         )
     session.commit()
 
-    response = admin_client.get("/api/projects?limit=2")
+    response = admin_client.get(f"{PROJECTS_URL}?limit=2")
     assert response.status_code == 200
     assert len(response.json()) == 2
 
-    response = admin_client.get("/api/projects?offset=3")
+    response = admin_client.get(f"{PROJECTS_URL}?offset=3")
     assert response.status_code == 200
     assert len(response.json()) == 2
 
 
-def test_create_project_slug_case_sensitivity(
-    admin_client: TestClient, project: Project
-) -> None:
-    response = admin_client.post(
-        "/api/projects",
-        json={
-            "title": "Another project",
-            "slug": "A-New-Project",
-            "description": "same slug different case",
-            "tags": [],
-            "published": True,
-        },
-    )
-    assert response.status_code in (201, 409)
+def test_get_project_by_slug(admin_client: TestClient, project: Project) -> None:
+    response = admin_client.get(f"{PROJECTS_URL}/a-new-project")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == project.title
+    assert data["description"] == project.description
+    assert data["published"] is True
 
 
-def test_update_project_not_found(admin_client: TestClient) -> None:
-    response = admin_client.put(
-        "/api/projects/nonexistent", json={"description": "nope"}
-    )
+def test_get_project_not_found(client: TestClient) -> None:
+    response = client.get(f"{PROJECTS_URL}/nope")
     assert response.status_code == 404
 
 
-def test_update_project_tags_empty(admin_client: TestClient, project: Project) -> None:
-    response = admin_client.put("/api/projects/a-new-project", json={"tags": []})
-
-    assert response.status_code == 200
-    assert response.json()["tags"] == []
-
-
-def test_delete_project_not_found(admin_client: TestClient) -> None:
-    response = admin_client.delete("/api/projects/nonexistent")
-    assert response.status_code == 404
-
-
-def test_create_project_with_demo_url(
-    admin_client: TestClient, session: Session
+def test_get_project_not_published(
+    client: TestClient, unpublished_project: Project, session: Session
 ) -> None:
-    response = admin_client.post(
-        "/api/projects",
-        json={
-            "title": "demo-project",
-            "slug": "demo-project",
-            "description": "a project with demo",
-            "tags": [],
-            "published": True,
-            "demo_url": "https://demo.example.com",
-        },
-    )
-
-    assert response.status_code == 201
-    assert response.json()["demo_url"] == "https://demo.example.com"
-
-
-def test_update_project_demo_url(admin_client: TestClient, project: Project) -> None:
-    response = admin_client.put(
-        "/api/projects/a-new-project", json={"demo_url": "https://demo.example.com"}
-    )
-
-    assert response.status_code == 200
-    assert response.json()["demo_url"] == "https://demo.example.com"
+    response = client.get(f"{PROJECTS_URL}/draft")
+    assert response.status_code == 404


### PR DESCRIPTION
## Résumé

- Routes publiques : `GET /projects`, `GET /projects/{slug}` (projets publiés uniquement)
- Routes admin : `GET /admin/projects`, `POST /admin/projects`, `PUT /admin/projects/{slug}`, `DELETE /admin/projects/{slug}` (authentification requise)
- Renommage de `_get_project_or_404` → `get_project_or_404` pour réutilisation entre les deux routeurs
- Tests séparés : `test_projects.py` (public) et `test_admin_projects.py` (admin)

Closes #1

## Type de changement

- [x] Refactoring

## Tests

- [x] Les tests existants passent (`uv run pytest`)
- [x] De nouveaux tests ont été ajoutés si nécessaire

## Checklist

- [x] Le code respecte les conventions du projet (`ruff`, `mypy`)
- [x] La PR est liée à une issue (`Closes #1`)