### PR TITLE
feat: add alternance support to education model

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -114,8 +114,11 @@ class Education(SQLModel, table=True):
     degree: str = Field(max_length=200)
     location: str | None = Field(default=None, max_length=200)
     year: int
+    is_alternance: bool = Field(default=False)
+    experience_id: int | None = Field(default=None, foreign_key="experience.id")
     profile_id: int | None = Field(default=None, foreign_key="profile.id", index=True)
 
+    experience: Experience | None = Relationship()
     profile: Profile | None = Relationship(back_populates="education")
 
 

--- a/backend/app/routers/admin/profile.py
+++ b/backend/app/routers/admin/profile.py
@@ -1,5 +1,5 @@
 import structlog
-from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlmodel import Session
 
 import app.uploads as file_uploads
@@ -44,9 +44,18 @@ def update_profile(
         ]
 
     if education_data is not None:
-        profile.education = [
-            Education(**e, profile_id=profile.id) for e in education_data
-        ]
+        education_list = []
+        for e in education_data:
+            exp_id = e.get("experience_id")
+            if exp_id is not None:
+                exp = session.get(Experience, exp_id)
+                if exp is None or exp.profile_id != profile.id:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                        detail=f"Experience {exp_id} not found or does not belong to this profile",
+                    )
+            education_list.append(Education(**e, profile_id=profile.id))
+        profile.education = education_list
 
     if social_links_data is not None:
         profile.social_links = [

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 
-from pydantic import BaseModel, EmailStr, Field, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator, model_validator
 
 
 class TagRead(BaseModel):
@@ -102,6 +102,15 @@ class EducationCreate(BaseModel):
     degree: str = Field(min_length=1, max_length=200)
     location: str | None = Field(default=None, max_length=200)
     year: int
+    is_alternance: bool = False
+    experience_id: int | None = None
+
+    @model_validator(mode="after")
+    def check_alternance_consistency(self) -> "EducationCreate":
+        """Ensure experience_id is only set when is_alternance is True."""
+        if self.experience_id is not None and not self.is_alternance:
+            raise ValueError("experience_id required is_alternance=True")
+        return self
 
 
 class EducationRead(BaseModel):
@@ -110,6 +119,9 @@ class EducationRead(BaseModel):
     degree: str
     location: str | None
     year: int
+    is_alternance: bool
+    experience_id: int | None
+    experience: ExperienceRead | None
 
 
 class SocialLinkCreate(BaseModel):

--- a/backend/migrations/versions/aaa0815b4958_add_is_alternance_and_experience_id_to_.py
+++ b/backend/migrations/versions/aaa0815b4958_add_is_alternance_and_experience_id_to_.py
@@ -1,0 +1,40 @@
+"""add is_alternance and experience_id to education
+
+Revision ID: aaa0815b4958
+Revises: 8e7c653cc854
+Create Date: 2026-02-22 16:30:42.108616
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "aaa0815b4958"
+down_revision: str | Sequence[str] | None = "8e7c653cc854"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("education", recreate="always") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_alternance", sa.Boolean(), nullable=False, server_default=sa.false()
+            )
+        )
+        batch_op.add_column(sa.Column("experience_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_education_experience_id", "experience", ["experience_id"], ["id"]
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("education", recreate="always") as batch_op:
+        batch_op.drop_constraint("fk_education_experience_id", type_="foreignkey")
+        batch_op.drop_column("experience_id")
+        batch_op.drop_column("is_alternance")

--- a/backend/tests/routers/admin/test_profile.py
+++ b/backend/tests/routers/admin/test_profile.py
@@ -1,3 +1,4 @@
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -386,3 +387,140 @@ def test_upload_resume_with_no_auth(client: TestClient, upload_dirs: None) -> No
     )
 
     assert response.status_code == 401
+
+
+def test_update_profile_with_alternance_education(admin_client: TestClient) -> None:
+    admin_client.put(
+        ADMIN_PROFILE_URL,
+        json={
+            "experiences": [
+                {
+                    "company": "Acme",
+                    "position": "Dev",
+                    "start_date": "2022-09-01",
+                    "end_date": "2024-06-30",
+                }
+            ]
+        },
+    )
+    profile = admin_client.put(ADMIN_PROFILE_URL, json={}).json()
+    exp_id = profile["experiences"][0]["id"]
+
+    response = admin_client.put(
+        ADMIN_PROFILE_URL,
+        json={
+            "education": [
+                {
+                    "school": "IUT",
+                    "degree": "BUT Info",
+                    "year": 2024,
+                    "is_alternance": True,
+                    "experience_id": exp_id,
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    edu = response.json()["education"][0]
+    assert edu["is_alternance"] is True
+    assert edu["experience_id"] == exp_id
+    assert edu["experience"]["company"] == "Acme"
+
+
+def test_update_profile_education_experience_id_requires_is_alternance(
+    admin_client: TestClient,
+) -> None:
+    admin_client.put(
+        ADMIN_PROFILE_URL,
+        json={
+            "experiences": [
+                {"company": "Acme", "position": "Dev", "start_date": "2022-09-01"}
+            ]
+        },
+    )
+    profile = admin_client.put(ADMIN_PROFILE_URL, json={}).json()
+    exp_id = profile["experiences"][0]["id"]
+
+    response = admin_client.put(
+        ADMIN_PROFILE_URL,
+        json={
+            "education": [
+                {
+                    "school": "IUT",
+                    "degree": "BUT",
+                    "year": 2024,
+                    "is_alternance": False,
+                    "experience_id": exp_id,
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_profile_education_invalid_experience_id(
+    admin_client: TestClient,
+) -> None:
+    response = admin_client.put(
+        ADMIN_PROFILE_URL,
+        json={
+            "education": [
+                {
+                    "school": "IUT",
+                    "degree": "BUT",
+                    "year": 2024,
+                    "is_alternance": True,
+                    "experience_id": 9999,
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_profile_education_experience_wrong_profile(
+    admin_client: TestClient, session: Session
+) -> None:
+    from app.models import Experience as ExpModel
+
+    orphan = ExpModel(
+        company="Other", position="Dev", start_date=date(2022, 1, 1), profile_id=9999
+    )
+    session.add(orphan)
+    session.commit()
+    session.refresh(orphan)
+
+    response = admin_client.put(
+        ADMIN_PROFILE_URL,
+        json={
+            "education": [
+                {
+                    "school": "IUT",
+                    "degree": "BUT",
+                    "year": 2024,
+                    "is_alternance": True,
+                    "experience_id": orphan.id,
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_profile_education_default_not_alternance(
+    admin_client: TestClient,
+) -> None:
+    response = admin_client.put(
+        ADMIN_PROFILE_URL,
+        json={"education": [{"school": "MIT", "degree": "CS", "year": 2020}]},
+    )
+
+    assert response.status_code == 200
+    edu = response.json()["education"][0]
+    assert edu["is_alternance"] is False
+    assert edu["experience_id"] is None
+    assert edu["experience"] is None


### PR DESCRIPTION
## Résumé

- Ajoute `is_alternance` et `experience_id` au modèle `Education`
- Ajoute la relation `Education → Experience` (unidirectionnelle)
- Valide la cohérence : `experience_id` ne peut être renseigné que si `is_alternance=True`
- Valide que l'expérience liée appartient au même profil
- Migration Alembic (batch mode pour SQLite)

## Plan de test

- [x] `uv run alembic upgrade head`
- [ ] `uv run pytest`
- [x] `uv run mypy app/`
- [ ] `uv run ruff check .`

Closes #41