### PR TITLE
feat: add Docker support for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Self-hosted developer portfolio — FastAPI REST API + Vue.js 3 SPA | Docker + G
 
 ## Tech Stack
 
-| Layer        | Technology                                                                            |
-| ------------ | ------------------------------------------------------------------------------------- |
-| **Backend**  | [FastAPI](https://fastapi.tiangolo.com/) — Python 3.12                                |
-| **Frontend** | [Vue.js 3](https://vuejs.org/) — TypeScript + [TailwindCSS](https://tailwindcss.com/) |
+| Layer        | Technology                                                                                                      |
+| ------------ | --------------------------------------------------------------------------------------------------------------- |
+| **Backend**  | [FastAPI](https://fastapi.tiangolo.com/) — Python 3.12                                                          |
+| **Frontend** | [Vue.js 3](https://vuejs.org/) — TypeScript + [TailwindCSS](https://tailwindcss.com/)                           |
 | **Database** | SQLite via [SQLModel](https://sqlmodel.tiangolo.com/) + [Alembic](https://alembic.sqlalchemy.org/) (migrations) |
-| **Auth**     | JWT (single-user)                                                                     |
-| **Deploy**   | [Coolify](https://coolify.io/) (self-hosted PaaS) + Cloudflare Tunnels                |
-| **CI/CD**    | GitHub Actions → Proxmox (self-hosted)                                                |
+| **Auth**     | JWT (single-user)                                                                                               |
+| **Deploy**   | [Coolify](https://coolify.io/) (self-hosted PaaS) + Cloudflare Tunnels                                          |
+| **CI/CD**    | GitHub Actions → Proxmox (self-hosted)                                                                          |
 
 ### Code Quality
 
@@ -29,7 +29,7 @@ Self-hosted developer portfolio — FastAPI REST API + Vue.js 3 SPA | Docker + G
 - [pyenv](https://github.com/pyenv/pyenv) — Python version management
 - [uv](https://docs.astral.sh/uv/) — Fast Python package manager
 - [Node.js](https://nodejs.org/) ≥ 18 — For the Vue.js frontend
-- [Docker](https://www.docker.com/) & Docker Compose — For production deployment
+- [Docker](https://www.docker.com/) & Docker Compose — For containerized deployment
 
 ## Getting Started
 
@@ -118,6 +118,22 @@ pre-commit install
 
 # Run all hooks manually
 pre-commit run --all-files
+```
+
+### Docker (dev)
+
+  ```bash
+  # Build et lancer l'API
+  docker compose up --build
+
+  # En arrière-plan
+  docker compose up -d
+
+  # Logs
+  docker compose logs -f api
+
+  # Arrêter
+  docker compose down
 ```
 
 ## License

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,15 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+tests/
+data/
+uploads/
+.env
+.env.*
+*.md

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.12-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+FROM python:3.12-slim AS runtime
+
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+
+COPY app/ app/
+COPY migrations/ migrations/
+COPY alembic.ini .
+
+RUN mkdir -p data uploads/avatars uploads/resumes \
+    && chown -R appuser:appuser /app
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+USER appuser
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,19 @@
+services:
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - api_data:/app/data
+      - api_uploads:/app/uploads
+    env_file:
+      - ./backend/.venv
+    command: >
+      sh -c "alembic upgrade head &&
+             uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 2"
+    restart: unless-stopped
+volumes:
+  api_data:
+  api_uploads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend/app:/app/app
+      - ./backend/migrations:/app/migrations
+      - ./backend/data:/app/data
+      - ./backend/uploads:/app/uploads
+    env_file:
+      - ./backend/.env
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
## Résumé

- Ajout d'un `Dockerfile` multi-stage (builder + runtime) avec image `python:3.12-slim`
- `docker-compose.yml` pour le développement (hot reload, volumes montés)
- `docker-compose.prod.yml` pour la production (Alembic + Uvicorn, volumes nommés, restart policy)
- `.dockerignore` pour exclure les fichiers inutiles de l'image
- Mise à jour du README avec les commandes Docker

Closes #18

## Plan de test

- [ ] `docker compose up --build` — l'image se build sans erreur
- [ ] API accessible sur http://localhost:8000
- [ ] Docs disponibles sur http://localhost:8000/docs
- [ ] Les volumes data/ et uploads/ persistent après `docker compose down && docker compose up`