### PR TITLE
fix: split auth.ts into server and client modules

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,8 @@
 
   This policy covers:
   - **Backend** — FastAPI API (authentication, data validation, dependencies)
-  - **Frontend** — Vue.js 3 SPA (when available)
-  - **Infrastructure** — Docker, Caddy, deployment configuration
+  - **Frontend** — Next.js (App Router, TypeScript)
+  - **Infrastructure** — Docker, Coolify, Cloudflare Tunnels
 
   ## Reporting a Vulnerability
 

--- a/frontend/components/admin/projects/ProjectForm.tsx
+++ b/frontend/components/admin/projects/ProjectForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ApiError, apiFetch } from "@/lib/api";
-import { getClientToken } from "@/lib/auth";
+import { getClientToken } from "@/lib/auth.client";
 import { Project } from "@/types/api";
 import { useRouter } from "next/navigation";
 import { useState } from "react";

--- a/frontend/components/admin/skills/SkillForm.tsx
+++ b/frontend/components/admin/skills/SkillForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ApiError, apiFetch } from "@/lib/api";
-import { getClientToken } from "@/lib/auth";
+import { getClientToken } from "@/lib/auth.client";
 import { Skill } from "@/types/api";
 import { useRouter } from "next/navigation";
 import { useState } from "react";

--- a/frontend/lib/auth.client.ts
+++ b/frontend/lib/auth.client.ts
@@ -1,0 +1,6 @@
+export function getClientToken() {
+  return document.cookie
+    .split("; ")
+    .find((c) => c.startsWith("token="))
+    ?.split("=")[1];
+}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -4,10 +4,3 @@ export async function getToken() {
   const cookieStore = await cookies();
   return cookieStore.get("token")?.value;
 }
-
-export function getClientToken() {
-  return document.cookie
-    .split("; ")
-    .find((c) => c.startsWith("token="))
-    ?.split("=")[1];
-}


### PR DESCRIPTION
Déplace `getClientToken` dans `lib/auth.client.ts` pour éviter que `next/headers` soit bundlé dans les Client Components, ce qui causait un échec du build en production.

## Changements
- Création de `frontend/lib/auth.client.ts` avec `getClientToken`
- Suppression de `getClientToken` de `frontend/lib/auth.ts`
- Mise à jour des imports dans `ProjectForm.tsx` et `SkillForm.tsx`

Closes #109