### PR TITLE
fix(backend): set explicit UID/GID 9999 for appuser

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 FROM python:3.12-slim AS runtime
 
-RUN groupadd -r appuser && useradd -r -g appuser appuser
+RUN groupadd -r -g 9999 appuser && useradd -r -u 9999 -g appuser appuser
 
 WORKDIR /app
 


### PR DESCRIPTION
Closes #148

## Résumé
- Force l'UID/GID de `appuser` à 9999 dans le Dockerfile backend
- Corrige l'erreur `unable to open database file` en production : le volume `/srv/portfolio/data` est `chown 9999:9999` sur l'hôte, l'UID dans le conteneur doit correspondre

## Plan de test
- [ ] Déployer en production
- [ ] Vérifier que le backend démarre sans erreur SQLite
- [ ] Vérifier que le frontend répond correctement