### PR TITLE
fix(frontend): replace flag emojis with SVG using country-flag-icons

### DIFF
--- a/frontend/components/LocaleSwitcher.tsx
+++ b/frontend/components/LocaleSwitcher.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRouter, usePathname } from "@/i18n/navigation";
-import { useLocale, useTranslations } from "next-intl";
+import { useLocale } from "next-intl";
+import { FR, GB } from "country-flag-icons/react/3x2";
 
 export default function LocaleSwitcher({
   mobile = false,
@@ -11,7 +12,9 @@ export default function LocaleSwitcher({
   const router = useRouter();
   const pathname = usePathname();
   const locale = useLocale();
-  const t = useTranslations("nav");
+  const flagStyle = "h-auto w-5";
+  const FlagComponent = locale === "fr" ? GB : FR;
+  const label = locale === "fr" ? "English" : "Français";
 
   function switchLocale(newLocale: string) {
     router.replace(pathname, { locale: newLocale });
@@ -26,7 +29,13 @@ export default function LocaleSwitcher({
           : "cursor-pointer px-3 py-1 text-xs font-semibold text-gray-600 transition-colors hover:text-blue-600"
       }
     >
-      {mobile ? t("switchLangMobile") : t("switchLang")}
+      {mobile ? (
+        <span className="flex items-center gap-2">
+          {label} <FlagComponent className={flagStyle} />
+        </span>
+      ) : (
+        <FlagComponent className={flagStyle} />
+      )}
     </button>
   );
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -5,9 +5,7 @@
     "projects": "Projects",
     "skills": "Skills",
     "experiences": "Experiences",
-    "contact": "Contact",
-    "switchLang": "🇫🇷",
-    "switchLangMobile": "Français 🇫🇷"
+    "contact": "Contact"
   },
   "skills": {
     "title": "Skills",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -5,9 +5,7 @@
     "projects": "Projets",
     "skills": "Compétences",
     "experiences": "Expériences",
-    "contact": "Contact",
-    "switchLang": "🇬🇧",
-    "switchLangMobile": "English 🇬🇧"
+    "contact": "Contact"
   },
   "skills": {
     "title": "Compétences",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@icons-pack/react-simple-icons": "^13.11.1",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-query-devtools": "^5.91.3",
+        "country-flag-icons": "^1.6.15",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "next-intl": "^4.8.3",
@@ -3233,6 +3234,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/country-flag-icons": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.6.15.tgz",
+      "integrity": "sha512-92HoA8l6DluEidku8tKBftjuFRj4Rv3zDW1lXxCuNnqAxhUSkvso9gM/Afj4F5BnK+wneHIe3ydI+s+4NA29/Q==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@icons-pack/react-simple-icons": "^13.11.1",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
+    "country-flag-icons": "^1.6.15",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "next-intl": "^4.8.3",


### PR DESCRIPTION
Closes #125

## Résumé
- Installe `country-flag-icons`
- Remplace les emojis 🇫🇷/🇬🇧 dans `LocaleSwitcher` par des composants SVG `FR`/`GB`
- Mode desktop : drapeau seul
- Mode mobile : texte + drapeau côte à côte

## Plan de test
- [ ] Vérifier l'affichage du drapeau en desktop (nav principale)
- [ ] Vérifier l'affichage texte + drapeau en mobile (menu hamburger)
- [ ] Vérifier que le switch de langue fonctionne dans les deux modes