### PR TITLE
fix(frontend): redirect to login on 401 in admin pages

### DIFF
--- a/frontend/app/[locale]/admin/(dashboard)/contact/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/contact/page.tsx
@@ -1,27 +1,22 @@
 import ContactTable from "@/components/admin/contact/ContactTable";
-import { ApiError, apiFetch } from "@/lib/api";
+import { adminFetch } from "@/lib/admin";
+import { apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { ContactMessage } from "@/types/api";
-import { redirect } from "next/navigation";
 
 export default async function ContactPage({
   params,
 }: {
   params: Promise<{ locale: string }>;
 }) {
-  const token = await getToken();
-  let messages: ContactMessage[] = [];
-  try {
-    messages = await apiFetch<ContactMessage[]>("/api/admin/contact", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-  } catch (error) {
-    if (error instanceof ApiError && error.status === 401) {
-      const { locale } = await params;
-      return redirect(`/${locale}/admin/login`);
-    }
-    throw error;
-  }
+  const [token, { locale }] = await Promise.all([getToken(), params]);
+  const messages = await adminFetch(
+    () =>
+      apiFetch<ContactMessage[]>("/api/admin/contact", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    locale,
+  );
 
   return (
     <div>

--- a/frontend/app/[locale]/admin/(dashboard)/education/[id]/edit/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/education/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 import EducationForm from "@/components/admin/education/EducationForm";
+import { adminFetch } from "@/lib/admin";
 import { ApiError, apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Education } from "@/types/api";
@@ -7,13 +8,16 @@ import { notFound } from "next/navigation";
 export default async function EditEducationPage({
   params,
 }: {
-  params: Promise<{ id: string }>;
+  params: Promise<{ locale: string; id: string }>;
 }) {
-  const { id } = await params;
-  const token = getToken();
+  const { locale, id } = await params;
+  const token = await getToken();
   let education: Education | undefined = undefined;
   try {
-    education = await apiFetch<Education>(`/api/education/${id}`);
+    education = await adminFetch(
+      () => apiFetch<Education>(`/api/education/${id}`),
+      locale,
+    );
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {
       return notFound();
@@ -25,7 +29,7 @@ export default async function EditEducationPage({
       <h1 className="mb-6 text-2xl font-bold text-slate-800">
         Modifier - {education.school}
       </h1>
-      <EducationForm initialData={education} token={await token} />
+      <EducationForm initialData={education} token={token} />
     </div>
   );
 }

--- a/frontend/app/[locale]/admin/(dashboard)/education/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/education/page.tsx
@@ -4,10 +4,16 @@ import { Education } from "@/types/api";
 import { Link } from "@/i18n/navigation";
 import { Plus } from "lucide-react";
 import EducationTable from "@/components/admin/education/EducationTable";
+import { adminFetch } from "@/lib/admin";
 
-export default async function EducationPage() {
+export default async function EducationPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const [educations, token] = await Promise.all([
-    apiFetch<Education[]>("/api/education"),
+    adminFetch(() => apiFetch<Education[]>("/api/education"), locale),
     getToken(),
   ]);
 

--- a/frontend/app/[locale]/admin/(dashboard)/experiences/[id]/edit/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/experiences/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 import ExperienceForm from "@/components/admin/experiences/ExperienceForm";
+import { adminFetch } from "@/lib/admin";
 import { ApiError, apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Experience } from "@/types/api";
@@ -7,13 +8,15 @@ import { notFound } from "next/navigation";
 export default async function EditExperiencePage({
   params,
 }: {
-  params: Promise<{ id: string }>;
+  params: Promise<{ locale: string; id: string }>;
 }) {
-  const { id } = await params;
-  const token = getToken();
+  const [token, { locale, id }] = await Promise.all([getToken(), params]);
   let experience: Experience | undefined = undefined;
   try {
-    experience = await apiFetch<Experience>(`/api/experiences/${id}`);
+    experience = await adminFetch(
+      () => apiFetch<Experience>(`/api/experiences/${id}`),
+      locale,
+    );
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {
       return notFound();
@@ -25,7 +28,7 @@ export default async function EditExperiencePage({
       <h1 className="mb-6 text-2xl font-bold text-slate-800">
         Modifier - {experience.company}
       </h1>
-      <ExperienceForm initialData={experience} token={await token} />
+      <ExperienceForm initialData={experience} token={token} />
     </div>
   );
 }

--- a/frontend/app/[locale]/admin/(dashboard)/experiences/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/experiences/page.tsx
@@ -4,10 +4,16 @@ import { getToken } from "@/lib/auth";
 import { Experience } from "@/types/api";
 import { Link } from "@/i18n/navigation";
 import { Plus } from "lucide-react";
+import { adminFetch } from "@/lib/admin";
 
-export default async function ExperiencesPage() {
+export default async function ExperiencesPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const [experiences, token] = await Promise.all([
-    apiFetch<Experience[]>("/api/experiences"),
+    adminFetch(() => apiFetch<Experience[]>("/api/experiences"), locale),
     getToken(),
   ]);
 

--- a/frontend/app/[locale]/admin/(dashboard)/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/page.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@/i18n/navigation";
+import { adminFetch } from "@/lib/admin";
 import { apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import {
@@ -10,19 +11,32 @@ import {
 } from "@/types/api";
 import { Briefcase, FolderOpen, GraduationCap, Wrench } from "lucide-react";
 
-export default async function AdminPage() {
+export default async function AdminPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
   const token = await getToken();
+  const { locale } = await params;
   const [projects, skills, experiences, education, messages] =
     await Promise.all([
-      apiFetch<Project[]>("/api/admin/projects", {
-        headers: { Authorization: `Bearer ${token}` },
-      }),
-      apiFetch<Skill[]>("/api/skills"),
-      apiFetch<Experience[]>("/api/experiences"),
-      apiFetch<Education[]>("/api/education"),
-      apiFetch<ContactMessage[]>("/api/admin/contact", {
-        headers: { Authorization: `Bearer ${token}` },
-      }),
+      adminFetch(
+        () =>
+          apiFetch<Project[]>("/api/admin/projects", {
+            headers: { Authorization: `Bearer ${token}` },
+          }),
+        locale,
+      ),
+      adminFetch(() => apiFetch<Skill[]>("/api/skills"), locale),
+      adminFetch(() => apiFetch<Experience[]>("/api/experiences"), locale),
+      adminFetch(() => apiFetch<Education[]>("/api/education"), locale),
+      adminFetch(
+        () =>
+          apiFetch<ContactMessage[]>("/api/admin/contact", {
+            headers: { Authorization: `Bearer ${token}` },
+          }),
+        locale,
+      ),
     ]);
   const unread = messages
     .filter((m) => !m.read)

--- a/frontend/app/[locale]/admin/(dashboard)/profile/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/profile/page.tsx
@@ -1,11 +1,17 @@
 import ProfileForm from "@/components/admin/profile/ProfileForm";
+import { adminFetch } from "@/lib/admin";
 import { apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Profile } from "@/types/api";
 
-export default async function ProfilePage() {
+export default async function ProfilePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
   const [profile, token] = await Promise.all([
-    apiFetch<Profile>("/api/profile"),
+    adminFetch(() => apiFetch<Profile>("/api/profile"), locale),
     getToken(),
   ]);
 

--- a/frontend/app/[locale]/admin/(dashboard)/projects/[slug]/edit/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/projects/[slug]/edit/page.tsx
@@ -1,4 +1,5 @@
 import ProjectForm from "@/components/admin/projects/ProjectForm";
+import { adminFetch } from "@/lib/admin";
 import { apiFetch, ApiError } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Project } from "@/types/api";
@@ -7,16 +8,17 @@ import { notFound } from "next/navigation";
 export default async function EditProjectPage({
   params,
 }: {
-  params: Promise<{ slug: string }>;
+  params: Promise<{ locale: string; slug: string }>;
 }) {
-  const token = await getToken();
+  const [token, { locale, slug }] = await Promise.all([getToken(), params]);
   let project: Project | undefined = undefined;
   try {
-    project = await apiFetch<Project>(
-      `/api/admin/projects/${(await params).slug}`,
-      {
-        headers: { Authorization: `Bearer ${token}` },
-      },
+    project = await adminFetch(
+      () =>
+        apiFetch<Project>(`/api/admin/projects/${slug}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      locale,
     );
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {

--- a/frontend/app/[locale]/admin/(dashboard)/projects/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/projects/page.tsx
@@ -1,30 +1,24 @@
-import { ApiError, apiFetch } from "@/lib/api";
+import { apiFetch } from "@/lib/api";
 import { Project } from "@/types/api";
 import ProjectsTable from "@/components/admin/projects/ProjectsTable";
 import { Link } from "@/i18n/navigation";
-import { redirect } from "next/navigation";
 import { Plus } from "lucide-react";
 import { getToken } from "@/lib/auth";
+import { adminFetch } from "@/lib/admin";
 
 export default async function AdminProjectsPage({
   params,
 }: {
   params: Promise<{ locale: string }>;
 }) {
-  const token = await getToken();
-  let projects: Project[] | undefined = undefined;
-  try {
-    projects = await apiFetch<Project[]>("/api/admin/projects", {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-  } catch (error) {
-    if (error instanceof ApiError && error.status === 401) {
-      const { locale } = await params;
-      return redirect(`/${locale}/admin/login`);
-    } else {
-      throw error;
-    }
-  }
+  const [token, { locale }] = await Promise.all([getToken(), params]);
+  const projects = await adminFetch(
+    () =>
+      apiFetch<Project[]>("/api/admin/projects", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    locale,
+  );
 
   return (
     <div>

--- a/frontend/app/[locale]/admin/(dashboard)/skills/[id]/edit/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/skills/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
 import SkillForm from "@/components/admin/skills/SkillForm";
+import { adminFetch } from "@/lib/admin";
 import { ApiError, apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Skill } from "@/types/api";
@@ -7,12 +8,15 @@ import { notFound } from "next/navigation";
 export default async function EditSkillPage({
   params,
 }: {
-  params: Promise<{ id: string }>;
+  params: Promise<{ locale: string; id: string }>;
 }) {
-  const token = await getToken();
+  const [token, { locale, id }] = await Promise.all([getToken(), params]);
   let skill: Skill | undefined = undefined;
   try {
-    skill = await apiFetch<Skill>(`/api/skills/${(await params).id}`);
+    skill = await adminFetch(
+      () => apiFetch<Skill>(`/api/skills/${id}`),
+      locale,
+    );
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {
       return notFound();

--- a/frontend/app/[locale]/admin/(dashboard)/skills/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/skills/page.tsx
@@ -4,13 +4,23 @@ import { getToken } from "@/lib/auth";
 import { Skill } from "@/types/api";
 import { Link } from "@/i18n/navigation";
 import { Plus } from "lucide-react";
+import { adminFetch } from "@/lib/admin";
 
-export default async function AdminSkillsPage() {
-  const skills = await apiFetch<Skill[]>("/api/skills");
+export default async function AdminSkillsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const token = await getToken();
+  const skills = await adminFetch(
+    () => apiFetch<Skill[]>("/api/skills"),
+    locale,
+  );
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold text-slate-800">Compétences</h1>
-      <SkillsTable skills={skills} token={await getToken()} />
+      <SkillsTable skills={skills} token={token} />
       <div className="mt-4 flex justify-end">
         <Link
           href="/admin/skills/new"

--- a/frontend/lib/admin.ts
+++ b/frontend/lib/admin.ts
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+import { ApiError } from "./api";
+
+export async function adminFetch<T>(
+  fn: () => Promise<T>,
+  locale: string,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) {
+      return redirect(`/${locale}/admin/login`);
+    } else {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
Closes #161

## Résumé
- Crée `frontend/lib/admin.ts` avec `adminFetch<T>` — wrape `apiFetch` et redirige vers `/[locale]/admin/login` sur erreur 401
- Applique `adminFetch` sur les 11 pages admin qui font des appels API

## Plan de test
- [ ] Expirer le token (supprimer le cookie ou attendre expiration)
- [ ] Naviguer vers une page admin → redirection vers /admin/login