### PR TITLE
feat(frontend): add public education page

### DIFF
--- a/backend/app/routers/education.py
+++ b/backend/app/routers/education.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 
 import structlog
 from fastapi import APIRouter, Depends
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 
 from app.database import get_session
 from app.models import Education
@@ -16,7 +16,7 @@ logger = structlog.get_logger()
 @router.get("", response_model=list[EducationRead])
 def list_educations(session: Session = Depends(get_session)) -> Sequence[Education]:
     """List all educations."""
-    return session.exec(select(Education)).all()
+    return session.exec(select(Education).order_by(col(Education.year).desc())).all()
 
 
 @router.get("/{id}", response_model=EducationRead)

--- a/backend/tests/routers/test_education.py
+++ b/backend/tests/routers/test_education.py
@@ -46,6 +46,28 @@ def test_list_education(client: TestClient, education: Education) -> None:
     assert data[0]["year"] == 2022
 
 
+def test_list_experiences_sorted_by_date_descending(
+    client: TestClient, education: Education, session: Session
+) -> None:
+    second_education = Education(
+        school="Python school",
+        degree="Bachelor",
+        year=2023,
+        profile_id=education.profile_id,
+    )
+    session.add(second_education)
+    session.commit()
+
+    response = client.get(EDUCATION_URL)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data) == 2
+    assert data[0]["school"] == "Python school"
+    assert data[1]["school"] == "MIT"
+
+
 def test_get_education(client: TestClient, education: Education) -> None:
     response = client.get(f"{EDUCATION_URL}/{education.id}")
 

--- a/backend/tests/routers/test_education.py
+++ b/backend/tests/routers/test_education.py
@@ -46,7 +46,7 @@ def test_list_education(client: TestClient, education: Education) -> None:
     assert data[0]["year"] == 2022
 
 
-def test_list_experiences_sorted_by_date_descending(
+def test_list_education_sorted_by_date_descending(
     client: TestClient, education: Education, session: Session
 ) -> None:
     second_education = Education(

--- a/backend/tests/routers/test_education.py
+++ b/backend/tests/routers/test_education.py
@@ -46,7 +46,7 @@ def test_list_education(client: TestClient, education: Education) -> None:
     assert data[0]["year"] == 2022
 
 
-def test_list_education_sorted_by_date_descending(
+def test_list_education_sorted_by_year_descending(
     client: TestClient, education: Education, session: Session
 ) -> None:
     second_education = Education(

--- a/frontend/app/[locale]/education/page.tsx
+++ b/frontend/app/[locale]/education/page.tsx
@@ -2,6 +2,8 @@ import { apiFetch } from "@/lib/api";
 import { Education } from "@/types/api";
 import { getTranslations } from "next-intl/server";
 
+export const dynamic = "force-dynamic";
+
 export default async function EducationPage() {
   const [educations, t] = await Promise.all([
     apiFetch<Education[]>("/api/education"),

--- a/frontend/app/[locale]/education/page.tsx
+++ b/frontend/app/[locale]/education/page.tsx
@@ -1,0 +1,51 @@
+import { apiFetch } from "@/lib/api";
+import { Education } from "@/types/api";
+import { getTranslations } from "next-intl/server";
+
+export default async function EducationPage() {
+  const [educations, t] = await Promise.all([
+    apiFetch<Education[]>("/api/education"),
+    getTranslations("education"),
+  ]);
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16">
+      <h1 className="mb-10 text-center text-3xl font-bold text-gray-900">
+        {t("title")}
+      </h1>
+      <div className="flex flex-col gap-6">
+        {educations.map((education) => (
+          <div
+            key={education.id}
+            className="rounded-xl bg-white p-6 shadow-md hover:shadow-xl"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h2 className="text-base font-semibold text-gray-900">
+                  {education.degree}
+                </h2>
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium text-blue-600">
+                    {education.school}
+                  </p>
+                  {education.location && (
+                    <p className="text-xs text-gray-400">
+                      {education.location}
+                    </p>
+                  )}
+                  {education.is_alternance && (
+                    <span className="inline-block rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-600">
+                      {t("alternance")}
+                    </span>
+                  )}
+                </div>
+              </div>
+              <p className="text-xs whitespace-nowrap text-gray-500">
+                {education.year}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/Nav.tsx
+++ b/frontend/components/Nav.tsx
@@ -15,6 +15,7 @@ export default function Nav() {
     { href: "/projects", label: t("projects") },
     { href: "/skills", label: t("skills") },
     { href: "/experiences", label: t("experiences") },
+    { href: "/education", label: t("education") },
     { href: "/contact", label: t("contact") },
   ];
   const pathname = usePathname();

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -5,7 +5,8 @@
     "projects": "Projects",
     "skills": "Skills",
     "experiences": "Experiences",
-    "contact": "Contact"
+    "contact": "Contact",
+    "education": "Education"
   },
   "skills": {
     "title": "Skills",
@@ -34,5 +35,9 @@
   "home": {
     "contact-me": "Contact me",
     "see-my-projects": "See my projects"
+  },
+  "education": {
+    "title": "Education",
+    "alternance": "Apprenticeship"
   }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -5,7 +5,8 @@
     "projects": "Projets",
     "skills": "Compétences",
     "experiences": "Expériences",
-    "contact": "Contact"
+    "contact": "Contact",
+    "education": "Formations"
   },
   "skills": {
     "title": "Compétences",
@@ -34,5 +35,9 @@
   "home": {
     "contact-me": "Me contacter",
     "see-my-projects": "Voir mes projets"
+  },
+  "education": {
+    "title": "Formations",
+    "alternance": "Alternance"
   }
 }


### PR DESCRIPTION
Ajoute la page publique `/education` affichant la liste des formations, triées par année décroissante.

- Page publique avec badge Alternance
- Tri backend par `year DESC`
- Lien dans la navigation
- Traductions fr/en

Closes #171