### PR TITLE
perf: sort contact messages by date descending on backend

### DIFF
--- a/backend/app/routers/admin/contact.py
+++ b/backend/app/routers/admin/contact.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 
 from app.auth import get_current_admin
 from app.database import get_session
@@ -29,6 +29,7 @@ def list_messages(
     return session.exec(
         select(ContactMessage)
         .where(ContactMessage.deleted_at == None)  # noqa: E711
+        .order_by(col(ContactMessage.created_at).desc())
         .offset(offset)
         .limit(limit)
     ).all()

--- a/backend/tests/routers/admin/test_contact.py
+++ b/backend/tests/routers/admin/test_contact.py
@@ -43,8 +43,8 @@ def test_list_messages_admin(
 
     data = response.json()
     assert len(data) == 2
-    assert data[0]["name"] == "first"
-    assert data[1]["name"] == "second"
+    assert data[0]["name"] == "second"
+    assert data[1]["name"] == "first"
     assert "id" in data[0]
     assert "read" in data[0]
     assert "created_at" in data[0]

--- a/frontend/app/[locale]/admin/(dashboard)/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/page.tsx
@@ -39,9 +39,7 @@ export default async function AdminPage({
         locale,
       ),
     ]);
-  const unread = messages
-    .filter((m) => !m.read)
-    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+  const unread = messages.filter((m) => !m.read);
 
   return (
     <div>


### PR DESCRIPTION
Délègue le tri des messages au backend via `ORDER BY created_at DESC` sur `GET /api/admin/contact`, et supprime le tri côté client dans le dashboard.

Closes #177