### PR TITLE
refactor(backend): centralize experience and education fixtures in conftest.py

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,15 +1,20 @@
 from collections.abc import Generator
+from datetime import date, time, timedelta
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine
 from sqlmodel.pool import StaticPool
 
+import app.uploads as file_uploads
 from app.auth import get_current_admin, get_optional_admin
 from app.config import Settings, get_settings
 from app.database import get_session
 from app.main import app
 from app.models import (  # noqa: F401
+    Appointment,
+    AvailabilitySlot,
     ContactMessage,
     Education,
     Experience,
@@ -73,3 +78,130 @@ def settings_override() -> Generator[None]:
     app.dependency_overrides[get_settings] = lambda: test_settings
     yield
     app.dependency_overrides.pop(get_settings, None)
+
+
+@pytest.fixture
+def message(session: Session) -> ContactMessage:
+    message = ContactMessage(
+        name="first", email="first@test.com", subject="sub 1", message="message 1"
+    )
+    session.add(message)
+    session.commit()
+    session.refresh(message)
+    return message
+
+
+@pytest.fixture
+def education(session: Session) -> Education:
+    profile = Profile()
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+
+    education = Education(
+        school="MIT",
+        degree="Bachelor",
+        year=2022,
+        profile_id=profile.id,
+    )
+    session.add(education)
+    session.commit()
+    session.refresh(education)
+
+    return education
+
+
+@pytest.fixture
+def experience(session: Session) -> Experience:
+    profile = Profile()
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+
+    experience = Experience(
+        company="Acme",
+        position="backend developer",
+        start_date=date(2022, 1, 1),
+        profile_id=profile.id,
+    )
+    session.add(experience)
+    session.commit()
+    session.refresh(experience)
+
+    return experience
+
+
+@pytest.fixture
+def project(session: Session) -> Project:
+    project = Project(
+        title="a new project",
+        slug="a-new-project",
+        description="a description for a new project",
+        published=True,
+    )
+    session.add(project)
+    project.tags.append(Tag(name="python"))
+    project.tags.append(Tag(name="fastapi"))
+    session.commit()
+    session.refresh(project)
+    return project
+
+
+@pytest.fixture
+def unpublished_project(session: Session) -> Project:
+    unpublished = Project(
+        title="draft",
+        slug="draft",
+        description="wip",
+        published=False,
+    )
+    session.add(unpublished)
+    session.commit()
+    session.refresh(unpublished)
+    return unpublished
+
+
+@pytest.fixture
+def skill(session: Session) -> Skill:
+    profile = Profile()
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+
+    skill = Skill(name="Python", category="Backend", level=9, profile_id=profile.id)
+    session.add(skill)
+    session.commit()
+    session.refresh(skill)
+
+    return skill
+
+
+@pytest.fixture
+def slot(session: Session) -> AvailabilitySlot:
+    """Monday slot 09:00-10:00."""
+    s = AvailabilitySlot(day_of_week=0, start_time=time(9, 0), end_time=time(10, 0))
+    session.add(s)
+    session.commit()
+    session.refresh(s)
+    return s
+
+
+@pytest.fixture
+def appointment(session: Session) -> Appointment:
+    a = Appointment(
+        visitor_name="Bob",
+        visitor_email="bob@example.com",
+        appointment_date=date.today() + timedelta(days=7),
+        start_time=time(10, 0),
+        end_time=time(11, 0),
+    )
+    session.add(a)
+    session.commit()
+    session.refresh(a)
+    return a
+
+
+@pytest.fixture
+def upload_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(file_uploads, "AVATAR_DIR", tmp_path / "avatars")
+    monkeypatch.setattr(file_uploads, "RESUME_DIR", tmp_path / "resumes")

--- a/backend/tests/routers/admin/test_appointments.py
+++ b/backend/tests/routers/admin/test_appointments.py
@@ -1,27 +1,8 @@
-from datetime import date, time, timedelta
-
-import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session
 
 from app.models import Appointment
 
 ADMIN_APPOINTMENTS_URL = "/api/admin/appointments"
-
-
-@pytest.fixture
-def appointment(session: Session) -> Appointment:
-    a = Appointment(
-        visitor_name="Bob",
-        visitor_email="bob@example.com",
-        appointment_date=date.today() + timedelta(days=7),
-        start_time=time(10, 0),
-        end_time=time(11, 0),
-    )
-    session.add(a)
-    session.commit()
-    session.refresh(a)
-    return a
 
 
 def test_list_appointments(admin_client: TestClient, appointment: Appointment) -> None:

--- a/backend/tests/routers/admin/test_contact.py
+++ b/backend/tests/routers/admin/test_contact.py
@@ -1,21 +1,9 @@
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from app.models import ContactMessage
 
 ADMIN_CONTACT_URL = "/api/admin/contact"
-
-
-@pytest.fixture
-def message(session: Session) -> ContactMessage:
-    message = ContactMessage(
-        name="first", email="first@test.com", subject="sub 1", message="message 1"
-    )
-    session.add(message)
-    session.commit()
-    session.refresh(message)
-    return message
 
 
 def test_list_messages_admin(

--- a/backend/tests/routers/admin/test_education.py
+++ b/backend/tests/routers/admin/test_education.py
@@ -1,30 +1,9 @@
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from app.models import Education, Profile
+from app.models import Education
 
 ADMIN_EDUCATION_URL = "/api/admin/education"
-
-
-@pytest.fixture
-def education(session: Session) -> Education:
-    profile = Profile()
-    session.add(profile)
-    session.commit()
-    session.refresh(profile)
-
-    education = Education(
-        school="MIT",
-        degree="Bachelor",
-        year=2022,
-        profile_id=profile.id,
-    )
-    session.add(education)
-    session.commit()
-    session.refresh(education)
-
-    return education
 
 
 def test_create_education(admin_client: TestClient, session: Session) -> None:

--- a/backend/tests/routers/admin/test_experiences.py
+++ b/backend/tests/routers/admin/test_experiences.py
@@ -1,32 +1,9 @@
-from datetime import date
-
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from app.models import Experience, Profile
+from app.models import Experience
 
 ADMIN_EXPERIENCE_URL = "/api/admin/experiences"
-
-
-@pytest.fixture
-def experience(session: Session) -> Experience:
-    profile = Profile()
-    session.add(profile)
-    session.commit()
-    session.refresh(profile)
-
-    experience = Experience(
-        company="Acme",
-        position="backend developer",
-        start_date=date(2022, 1, 1),
-        profile_id=profile.id,
-    )
-    session.add(experience)
-    session.commit()
-    session.refresh(experience)
-
-    return experience
 
 
 def test_create_experience(admin_client: TestClient, session: Session) -> None:

--- a/backend/tests/routers/admin/test_profile.py
+++ b/backend/tests/routers/admin/test_profile.py
@@ -1,7 +1,6 @@
 from datetime import date
 from pathlib import Path
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
@@ -11,12 +10,6 @@ from app.models import Skill, SocialLink
 ADMIN_PROFILE_URL = "/api/admin/profile"
 AVATAR_URL = f"{ADMIN_PROFILE_URL}/avatar"
 RESUME_URL = f"{ADMIN_PROFILE_URL}/resume"
-
-
-@pytest.fixture
-def upload_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(file_uploads, "AVATAR_DIR", tmp_path / "avatars")
-    monkeypatch.setattr(file_uploads, "RESUME_DIR", tmp_path / "resumes")
 
 
 def test_update_profile(admin_client: TestClient) -> None:

--- a/backend/tests/routers/admin/test_projects.py
+++ b/backend/tests/routers/admin/test_projects.py
@@ -1,40 +1,9 @@
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
 from app.models import Project, Tag
 
 ADMIN_PROJECTS_URL = "api/admin/projects"
-
-
-@pytest.fixture
-def project(session: Session) -> Project:
-    project = Project(
-        title="a new project",
-        slug="a-new-project",
-        description="a description for a new project",
-        published=True,
-    )
-    session.add(project)
-    project.tags.append(Tag(name="python"))
-    project.tags.append(Tag(name="fastapi"))
-    session.commit()
-    session.refresh(project)
-    return project
-
-
-@pytest.fixture
-def unpublished_project(session: Session) -> Project:
-    unpublished = Project(
-        title="draft",
-        slug="draft",
-        description="wip",
-        published=False,
-    )
-    session.add(unpublished)
-    session.commit()
-    session.refresh(unpublished)
-    return unpublished
 
 
 def test_list_all_projects(

--- a/backend/tests/routers/admin/test_skills.py
+++ b/backend/tests/routers/admin/test_skills.py
@@ -1,25 +1,9 @@
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
-from app.models import Profile, Skill
+from app.models import Skill
 
 ADMIN_SKILL_URL = "/api/admin/skills"
-
-
-@pytest.fixture
-def skill(session: Session) -> Skill:
-    profile = Profile()
-    session.add(profile)
-    session.commit()
-    session.refresh(profile)
-
-    skill = Skill(name="Python", category="Backend", level=9, profile_id=profile.id)
-    session.add(skill)
-    session.commit()
-    session.refresh(skill)
-
-    return skill
 
 
 def test_create_skill(admin_client: TestClient, session: Session) -> None:

--- a/backend/tests/routers/test_appointments.py
+++ b/backend/tests/routers/test_appointments.py
@@ -1,6 +1,5 @@
 from datetime import date, time
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
@@ -8,16 +7,6 @@ from app.models import Appointment, AvailabilitySlot
 
 APPOINTMENTS_URL = "/api/appointments"
 AVAILABLE_URL = "/api/appointments/available"
-
-
-@pytest.fixture
-def slot(session: Session) -> AvailabilitySlot:
-    """Monday slot 09:00-10:00."""
-    s = AvailabilitySlot(day_of_week=0, start_time=time(9, 0), end_time=time(10, 0))
-    session.add(s)
-    session.commit()
-    session.refresh(s)
-    return s
 
 
 def next_weekday(weekday: int) -> date:

--- a/backend/tests/routers/test_contact.py
+++ b/backend/tests/routers/test_contact.py
@@ -1,21 +1,9 @@
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
 from app.models import ContactMessage
 
 CONTACT_URL = "/api/contact"
-
-
-@pytest.fixture
-def message(session: Session) -> ContactMessage:
-    message = ContactMessage(
-        name="first", email="first@test.com", subject="sub 1", message="message 1"
-    )
-    session.add(message)
-    session.commit()
-    session.refresh(message)
-    return message
 
 
 def test_send_message(client: TestClient, session: Session) -> None:

--- a/backend/tests/routers/test_education.py
+++ b/backend/tests/routers/test_education.py
@@ -1,30 +1,9 @@
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
-from app.models import Education, Profile
+from app.models import Education
 
 EDUCATION_URL = "/api/education"
-
-
-@pytest.fixture
-def education(session: Session) -> Education:
-    profile = Profile()
-    session.add(profile)
-    session.commit()
-    session.refresh(profile)
-
-    education = Education(
-        school="MIT",
-        degree="Bachelor",
-        year=2022,
-        profile_id=profile.id,
-    )
-    session.add(education)
-    session.commit()
-    session.refresh(education)
-
-    return education
 
 
 def test_list_education_empty(client: TestClient) -> None:

--- a/backend/tests/routers/test_experiences.py
+++ b/backend/tests/routers/test_experiences.py
@@ -1,32 +1,11 @@
 from datetime import date
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
-from app.models import Experience, Profile
+from app.models import Experience
 
 EXPERIENCE_URL = "/api/experiences"
-
-
-@pytest.fixture
-def experience(session: Session) -> Experience:
-    profile = Profile()
-    session.add(profile)
-    session.commit()
-    session.refresh(profile)
-
-    experience = Experience(
-        company="Acme",
-        position="backend developer",
-        start_date=date(2022, 1, 1),
-        profile_id=profile.id,
-    )
-    session.add(experience)
-    session.commit()
-    session.refresh(experience)
-
-    return experience
 
 
 def test_list_experience_empty(client: TestClient) -> None:

--- a/backend/tests/routers/test_projects.py
+++ b/backend/tests/routers/test_projects.py
@@ -1,40 +1,9 @@
-import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
-from app.models import Project, Tag
+from app.models import Project
 
 PROJECTS_URL = "api/projects"
-
-
-@pytest.fixture
-def project(session: Session) -> Project:
-    project = Project(
-        title="a new project",
-        slug="a-new-project",
-        description="a description for a new project",
-        published=True,
-    )
-    session.add(project)
-    project.tags.append(Tag(name="python"))
-    project.tags.append(Tag(name="fastapi"))
-    session.commit()
-    session.refresh(project)
-    return project
-
-
-@pytest.fixture
-def unpublished_project(session: Session) -> Project:
-    unpublished = Project(
-        title="draft",
-        slug="draft",
-        description="wip",
-        published=False,
-    )
-    session.add(unpublished)
-    session.commit()
-    session.refresh(unpublished)
-    return unpublished
 
 
 def test_list_projects_empty(client: TestClient) -> None:

--- a/backend/tests/routers/test_skills.py
+++ b/backend/tests/routers/test_skills.py
@@ -1,25 +1,8 @@
-import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session
 
-from app.models import Profile, Skill
+from app.models import Skill
 
 SKILL_URL = "api/skills"
-
-
-@pytest.fixture
-def skill(session: Session) -> Skill:
-    profile = Profile()
-    session.add(profile)
-    session.commit()
-    session.refresh(profile)
-
-    skill = Skill(name="Python", category="Backend", level=9, profile_id=profile.id)
-    session.add(skill)
-    session.commit()
-    session.refresh(skill)
-
-    return skill
 
 
 def test_list_skill_empty(client: TestClient) -> None:


### PR DESCRIPTION
Déplace les fixtures `experience` et `education` dans `tests/conftest.py` pour éviter la duplication entre les tests publics et admin.

Closes #137