### PR TITLE
fix(frontend): redirect to login if token is absent in admin pages

### DIFF
--- a/frontend/app/[locale]/admin/(dashboard)/contact/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/contact/page.tsx
@@ -3,6 +3,7 @@ import { adminFetch } from "@/lib/admin";
 import { apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { ContactMessage } from "@/types/api";
+import { redirect } from "next/navigation";
 
 export default async function ContactPage({
   params,
@@ -10,6 +11,8 @@ export default async function ContactPage({
   params: Promise<{ locale: string }>;
 }) {
   const [token, { locale }] = await Promise.all([getToken(), params]);
+  if (!token) redirect(`/${locale}/admin/login`);
+
   const messages = await adminFetch(
     () =>
       apiFetch<ContactMessage[]>("/api/admin/contact", {

--- a/frontend/app/[locale]/admin/(dashboard)/education/[id]/edit/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/education/[id]/edit/page.tsx
@@ -3,7 +3,7 @@ import { adminFetch } from "@/lib/admin";
 import { ApiError, apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Education } from "@/types/api";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 export default async function EditEducationPage({
   params,
@@ -12,6 +12,8 @@ export default async function EditEducationPage({
 }) {
   const { locale, id } = await params;
   const token = await getToken();
+  if (!token) redirect(`/${locale}/admin/login`);
+
   let education: Education | undefined = undefined;
   try {
     education = await adminFetch(

--- a/frontend/app/[locale]/admin/(dashboard)/education/new/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/education/new/page.tsx
@@ -1,7 +1,15 @@
 import EducationForm from "@/components/admin/education/EducationForm";
 import { getToken } from "@/lib/auth";
+import { redirect } from "next/navigation";
 
-export default async function NewEducationPage() {
+export default async function NewEducationPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const [token, { locale }] = await Promise.all([getToken(), params]);
+  if (!token) redirect(`/${locale}/admin/login`);
+
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold text-slate-800">

--- a/frontend/app/[locale]/admin/(dashboard)/education/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/education/page.tsx
@@ -5,6 +5,7 @@ import { Link } from "@/i18n/navigation";
 import { Plus } from "lucide-react";
 import EducationTable from "@/components/admin/education/EducationTable";
 import { adminFetch } from "@/lib/admin";
+import { redirect } from "next/navigation";
 
 export default async function EducationPage({
   params,
@@ -16,6 +17,7 @@ export default async function EducationPage({
     adminFetch(() => apiFetch<Education[]>("/api/education"), locale),
     getToken(),
   ]);
+  if (!token) redirect(`/${locale}/admin/login`);
 
   return (
     <div>

--- a/frontend/app/[locale]/admin/(dashboard)/experiences/[id]/edit/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/experiences/[id]/edit/page.tsx
@@ -3,7 +3,7 @@ import { adminFetch } from "@/lib/admin";
 import { ApiError, apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Experience } from "@/types/api";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 export default async function EditExperiencePage({
   params,
@@ -11,6 +11,8 @@ export default async function EditExperiencePage({
   params: Promise<{ locale: string; id: string }>;
 }) {
   const [token, { locale, id }] = await Promise.all([getToken(), params]);
+  if (!token) redirect(`/${locale}/admin/login`);
+
   let experience: Experience | undefined = undefined;
   try {
     experience = await adminFetch(

--- a/frontend/app/[locale]/admin/(dashboard)/experiences/new/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/experiences/new/page.tsx
@@ -1,8 +1,15 @@
 import ExperienceForm from "@/components/admin/experiences/ExperienceForm";
 import { getToken } from "@/lib/auth";
+import { redirect } from "next/navigation";
 
-export default async function NewExperiencePage() {
-  const token = await getToken();
+export default async function NewExperiencePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const [token, locale] = await Promise.all([getToken(), params]);
+  if (!token) redirect(`/${locale}/admin/login`);
+
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold text-slate-800">

--- a/frontend/app/[locale]/admin/(dashboard)/experiences/new/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/experiences/new/page.tsx
@@ -7,7 +7,7 @@ export default async function NewExperiencePage({
 }: {
   params: Promise<{ locale: string }>;
 }) {
-  const [token, locale] = await Promise.all([getToken(), params]);
+  const [token, { locale }] = await Promise.all([getToken(), params]);
   if (!token) redirect(`/${locale}/admin/login`);
 
   return (

--- a/frontend/app/[locale]/admin/(dashboard)/experiences/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/experiences/page.tsx
@@ -5,6 +5,7 @@ import { Experience } from "@/types/api";
 import { Link } from "@/i18n/navigation";
 import { Plus } from "lucide-react";
 import { adminFetch } from "@/lib/admin";
+import { redirect } from "next/navigation";
 
 export default async function ExperiencesPage({
   params,
@@ -16,6 +17,7 @@ export default async function ExperiencesPage({
     adminFetch(() => apiFetch<Experience[]>("/api/experiences"), locale),
     getToken(),
   ]);
+  if (!token) redirect(`/${locale}/admin/login`);
 
   return (
     <div>

--- a/frontend/app/[locale]/admin/(dashboard)/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/page.tsx
@@ -11,6 +11,7 @@ import {
   Skill,
 } from "@/types/api";
 import { Briefcase, FolderOpen, GraduationCap, Wrench } from "lucide-react";
+import { redirect } from "next/navigation";
 
 export default async function AdminPage({
   params,
@@ -19,6 +20,8 @@ export default async function AdminPage({
 }) {
   const token = await getToken();
   const { locale } = await params;
+  if (!token) redirect(`/${locale}/admin/login`);
+
   const [projects, skills, experiences, education, messages] =
     await Promise.all([
       adminFetch(

--- a/frontend/app/[locale]/admin/(dashboard)/profile/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/profile/page.tsx
@@ -3,6 +3,7 @@ import { adminFetch } from "@/lib/admin";
 import { apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Profile } from "@/types/api";
+import { redirect } from "next/navigation";
 
 export default async function ProfilePage({
   params,
@@ -14,6 +15,7 @@ export default async function ProfilePage({
     adminFetch(() => apiFetch<Profile>("/api/profile"), locale),
     getToken(),
   ]);
+  if (!token) redirect(`/${locale}/admin/login`);
 
   return (
     <div>

--- a/frontend/app/[locale]/admin/(dashboard)/projects/[slug]/edit/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/projects/[slug]/edit/page.tsx
@@ -3,7 +3,7 @@ import { adminFetch } from "@/lib/admin";
 import { apiFetch, ApiError } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Project } from "@/types/api";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 export default async function EditProjectPage({
   params,
@@ -11,6 +11,8 @@ export default async function EditProjectPage({
   params: Promise<{ locale: string; slug: string }>;
 }) {
   const [token, { locale, slug }] = await Promise.all([getToken(), params]);
+  if (!token) redirect(`/${locale}/admin/login`);
+
   let project: Project | undefined = undefined;
   try {
     project = await adminFetch(

--- a/frontend/app/[locale]/admin/(dashboard)/projects/new/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/projects/new/page.tsx
@@ -1,8 +1,15 @@
 import ProjectForm from "@/components/admin/projects/ProjectForm";
 import { getToken } from "@/lib/auth";
+import { redirect } from "next/navigation";
 
-export default async function NewProjectPage() {
-  const token = await getToken();
+export default async function NewProjectPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const [token, { locale }] = await Promise.all([getToken(), params]);
+  if (!token) redirect(`/${locale}/admin/login`);
+
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold text-slate-800">Nouveau projet</h1>

--- a/frontend/app/[locale]/admin/(dashboard)/projects/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/projects/page.tsx
@@ -5,6 +5,7 @@ import { Link } from "@/i18n/navigation";
 import { Plus } from "lucide-react";
 import { getToken } from "@/lib/auth";
 import { adminFetch } from "@/lib/admin";
+import { redirect } from "next/navigation";
 
 export default async function AdminProjectsPage({
   params,
@@ -12,6 +13,8 @@ export default async function AdminProjectsPage({
   params: Promise<{ locale: string }>;
 }) {
   const [token, { locale }] = await Promise.all([getToken(), params]);
+  if (!token) redirect(`/${locale}/admin/login`);
+
   const projects = await adminFetch(
     () =>
       apiFetch<Project[]>("/api/admin/projects", {

--- a/frontend/app/[locale]/admin/(dashboard)/skills/[id]/edit/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/skills/[id]/edit/page.tsx
@@ -3,7 +3,7 @@ import { adminFetch } from "@/lib/admin";
 import { ApiError, apiFetch } from "@/lib/api";
 import { getToken } from "@/lib/auth";
 import { Skill } from "@/types/api";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 export default async function EditSkillPage({
   params,
@@ -11,6 +11,7 @@ export default async function EditSkillPage({
   params: Promise<{ locale: string; id: string }>;
 }) {
   const [token, { locale, id }] = await Promise.all([getToken(), params]);
+  if (!token) redirect(`/${locale}/admin/login`);
   let skill: Skill | undefined = undefined;
   try {
     skill = await adminFetch(

--- a/frontend/app/[locale]/admin/(dashboard)/skills/new/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/skills/new/page.tsx
@@ -1,8 +1,15 @@
 import SkillForm from "@/components/admin/skills/SkillForm";
 import { getToken } from "@/lib/auth";
+import { redirect } from "next/navigation";
 
-export default async function NewSkillPage() {
-  const token = await getToken();
+export default async function NewSkillPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const [token, { locale }] = await Promise.all([getToken(), params]);
+  if (!token) redirect(`/${locale}/admin/login`);
+
   return (
     <div>
       <h1 className="mb-6 text-2xl font-bold text-slate-800">

--- a/frontend/app/[locale]/admin/(dashboard)/skills/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/skills/page.tsx
@@ -5,6 +5,7 @@ import { Skill } from "@/types/api";
 import { Link } from "@/i18n/navigation";
 import { Plus } from "lucide-react";
 import { adminFetch } from "@/lib/admin";
+import { redirect } from "next/navigation";
 
 export default async function AdminSkillsPage({
   params,
@@ -13,6 +14,8 @@ export default async function AdminSkillsPage({
 }) {
   const { locale } = await params;
   const token = await getToken();
+  if (!token) redirect(`/${locale}/admin/login`);
+
   const skills = await adminFetch(
     () => apiFetch<Skill[]>("/api/skills"),
     locale,


### PR DESCRIPTION
Ajoute un guard `if (!token) redirect(...)` dans toutes les pages admin qui utilisent `getToken()`.

Évite d'envoyer `Bearer undefined` à l'API quand le cookie token est absent.

Closes #157