### PR TITLE
feat: filter contact messages by read status

### DIFF
--- a/backend/app/routers/admin/contact.py
+++ b/backend/app/routers/admin/contact.py
@@ -18,6 +18,7 @@ logger = structlog.get_logger()
 def list_messages(
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=50, ge=1, le=100),
+    read: bool | None = Query(default=None),
     session: Session = Depends(get_session),
     _: str = Depends(get_current_admin),
 ) -> Sequence[ContactMessage]:
@@ -25,14 +26,18 @@ def list_messages(
 
     Soft-deleted messages are excluded.
     Supports pagination via `offset` and `limit` (max 100).
+    Supports filterings by read status via `read` (true/false).
     """
-    return session.exec(
+    query = (
         select(ContactMessage)
         .where(ContactMessage.deleted_at == None)  # noqa: E711
         .order_by(col(ContactMessage.created_at).desc())
         .offset(offset)
         .limit(limit)
-    ).all()
+    )
+    if read is not None:
+        query = query.where(ContactMessage.read == read)
+    return session.exec(query).all()
 
 
 @router.patch("/{message_id}/read", response_model=ContactRead)

--- a/backend/tests/routers/admin/test_contact.py
+++ b/backend/tests/routers/admin/test_contact.py
@@ -43,6 +43,48 @@ def test_list_messages_without_auth(client: TestClient) -> None:
     assert response.status_code == 401
 
 
+def test_list_messages_filter_unread(
+    admin_client: TestClient, session: Session
+) -> None:
+    session.add(
+        ContactMessage(
+            name="a", email="a@test.com", subject="s", message="m", read=True
+        )
+    )
+    session.add(
+        ContactMessage(
+            name="b", email="b@test.com", subject="s", message="m", read=False
+        )
+    )
+    session.commit()
+
+    response = admin_client.get(f"{ADMIN_CONTACT_URL}?read=false")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "b"
+
+
+def test_list_messages_filter_read(admin_client: TestClient, session: Session) -> None:
+    session.add(
+        ContactMessage(
+            name="a", email="a@test.com", subject="s", message="m", read=True
+        )
+    )
+    session.add(
+        ContactMessage(
+            name="b", email="b@test.com", subject="s", message="m", read=False
+        )
+    )
+    session.commit()
+
+    response = admin_client.get(f"{ADMIN_CONTACT_URL}?read=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "a"
+
+
 def test_mark_as_read(
     session: Session,
     admin_client: TestClient,

--- a/frontend/app/[locale]/admin/(dashboard)/page.tsx
+++ b/frontend/app/[locale]/admin/(dashboard)/page.tsx
@@ -36,13 +36,12 @@ export default async function AdminPage({
       adminFetch(() => apiFetch<Education[]>("/api/education"), locale),
       adminFetch(
         () =>
-          apiFetch<ContactMessage[]>("/api/admin/contact", {
+          apiFetch<ContactMessage[]>("/api/admin/contact?read=false", {
             headers: { Authorization: `Bearer ${token}` },
           }),
         locale,
       ),
     ]);
-  const unread = messages.filter((m) => !m.read);
 
   return (
     <div>
@@ -77,15 +76,15 @@ export default async function AdminPage({
         <h2 className="mb-3 text-lg font-semibold text-slate-800">
           Messages non lus{" "}
           <span className="ml-1 rounded-full bg-red-100 px-2 py-0.5 text-sm text-red-600">
-            {unread.length}
+            {messages.length}
           </span>
         </h2>
         <div className="rounded-xl bg-white shadow-md">
-          {unread.length === 0 ? (
+          {messages.length === 0 ? (
             <p className="p-6 text-sm text-slate-400">Aucun message non lu.</p>
           ) : (
             <ul className="divide-y divide-slate-100">
-              {unread.map((message) => (
+              {messages.map((message) => (
                 <li key={message.id}>
                   <Link
                     href="/admin/contact"


### PR DESCRIPTION
Ajoute un paramètre optionnel `read` sur `GET /api/admin/contact` :

- `?read=false` → messages non lus uniquement
- `?read=true` → messages lus uniquement
- sans paramètre → tous les messages

Le dashboard utilise désormais `?read=false` pour filtrer côté DB plutôt que côté client.

Closes #180